### PR TITLE
chore: adopt MAT workflow (bootstrap)

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,40 @@
+# MAT default .cursorignore — token/context hygiene for indexing @-mentions
+# Canonical copy lives here; repo root `.cursorignore` should stay aligned.
+# See: `.cursor/rules/cost-context-hygiene.mdc`, `scripts/validate_cost_context_hygiene_pack.py`
+
+# Dependencies & build outputs
+node_modules/
+dist/
+build/
+out/
+.next/
+.nuxt/
+.turbo/
+coverage/
+htmlcov/
+
+# Caches & compiled artifacts
+.cache/
+__pycache__/
+*.py[cod]
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/
+.tox/
+*.egg-info/
+
+# Logs & local env (never index secrets)
+*.log
+.env
+.env.*
+!.env.sample
+
+# Large generated / vendor trees (extend per repo)
+artifacts/run-traces/
+
+# ─── Escape hatch ─────────────────────────────────────────────────────────────
+# Tight ignores save tokens and reduce accidental secret exposure. When a slice
+# truly needs a path listed here (e.g. greenfield audit of build output, incident
+# response), remove or narrow the relevant lines in `.cursorignore` for that work,
+# document why in `docs/current-plan.md` or the session summary, and restore
+# strict patterns afterward. Do not permanently widen to "ignore nothing".

--- a/.cursorignore
+++ b/.cursorignore
@@ -32,6 +32,15 @@ __pycache__/
 # Large generated / vendor trees (extend per repo)
 artifacts/run-traces/
 
+# Stack-specific (WordPress) — merged from .mat/docs/templates/cursorignore-mat-wordpress
+wp-content/uploads/
+wp-content/upgrade/
+wp-content/cache/
+wp-content/backup*/
+wp-content/debug.log
+*.sql
+*.wpress
+
 # ─── Escape hatch ─────────────────────────────────────────────────────────────
 # Tight ignores save tokens and reduce accidental secret exposure. When a slice
 # truly needs a path listed here (e.g. greenfield audit of build output, incident

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,122 @@
+# .env.sample — Environment Variable Template
+# Copy this file to .env and fill in the required values.
+# The .env file is gitignored — never commit secrets to the repository.
+#
+# Reused from: disler/claude-code-hooks-mastery .env.sample
+# Added: Cursor-specific variables
+
+# ─── Observability Server ─────────────────────────────────────────────────────
+
+# URL of the local observability server (Bun + SQLite + Vue)
+# Default: http://localhost:3001/events
+OBSERVABILITY_SERVER_URL=http://localhost:3001/events
+
+# Optional: require Bearer token on POST /events and POST /api/events (see apps/server/README-OBSERVABILITY.md).
+# When set, hooks that POST events must see the same value (send_event.py sends it automatically).
+# OBSERVABILITY_API_TOKEN=
+
+# Optional: override allowed browser Origins for CORS + WebSocket (comma-separated). Defaults include local Vite + API ports.
+# OBSERVABILITY_CORS_ORIGINS=http://127.0.0.1:5173,http://localhost:5173
+
+# ─── Cursor-Specific ─────────────────────────────────────────────────────────
+
+# Project directory (auto-set by Cursor, but can be overridden for testing)
+# CURSOR_PROJECT_DIR=/path/to/your/project
+
+# Optional: correlate hook spawn traces under artifacts/agent-traces/<run-id>/events.jsonl
+# (see docs/mat-plan-team-spec.md and artifacts/agent-traces/README.md)
+# CURSOR_AGENT_TRACE_RUN_ID=my-experiment-2026-03-30
+
+# Optional: stable session label for observability when hook stdin omits session fields
+# (see docs/hook-payload-verification.md)
+# CURSOR_SESSION_ID=my-workspace-session
+
+# Enable macOS desktop notifications on agent Stop (replaces Claude Notification hooks)
+# Set to "true" to enable
+CURSOR_DESKTOP_NOTIFICATIONS=false
+
+# Store user prompts in session data (for beforeSubmitPrompt hook)
+CURSOR_STORE_PROMPTS=false
+
+# Generate agent names via LLM (for beforeSubmitPrompt hook)
+CURSOR_NAME_AGENT=false
+
+# Validate user prompts against blocked patterns (for beforeSubmitPrompt hook)
+CURSOR_VALIDATE_PROMPTS=false
+# Opt-in only: when true, patterns are evaluated in `.cursor/hooks/before_submit_prompt.py`
+# inside `validate_prompt()` — the shipped list is empty until you add explicit tuples.
+# Substring checks can false-positive; see docs/MAINTAINER.md#submit-time-prompt-validation-opt-in
+# CURSOR_VALIDATE_PROMPTS=true
+
+# Optional: cost-hygiene validator — override adoption `.mat/cost-hygiene-adoption.json` in CI
+# (strict = fail on missing .cursorignore fragments; warn_first = downgrades fragment gaps to WARN for existing-project).
+# # CURSOR_MAT_COST_HYGIENE_ENFORCE=strict
+
+# Log directory for hook events (default: <project>/logs)
+# CURSOR_HOOKS_LOG_DIR=/path/to/logs
+
+# ─── Lifecycle raw payload capture (opt-in; Phase 1 verification) ─────────────
+# Hooks read these from process environment first, then from this repo-root `.env`
+# via `.cursor/hooks/payload_capture.py` (no reliance on integrated-terminal exports).
+# CURSOR_HOOK_CAPTURE=1
+# CURSOR_HOOK_CAPTURE_EVENTS=sessionStart,sessionEnd,stop,preCompact
+# Optional custom path; absolute paths are used as-is, relative paths resolve from
+# the repo root. Default is <repo>/artifacts/phase1/raw_payloads/
+# CURSOR_HOOK_CAPTURE_DIR=artifacts/phase1/raw_payloads-session-audit
+#
+# Nest captures per composer session (subdirectory = sanitized conversation_id):
+# CURSOR_HOOK_CAPTURE_PER_SESSION=1
+
+# MAO post-build gate (artifacts/mao/gate.json). Set to 0/false/off to skip writes.
+# CURSOR_MAO_GATE=0
+
+# MAO PostToolUse todo-write observation (artifacts/mao/todo-write-events.jsonl, last snapshot).
+# Set to 0/false/off to skip. Does not call TodoWrite or spawn agents.
+# CURSOR_MAO_TODO_POST_TOOL_USE=0
+# Disable hook-written downstream readiness snapshot (unblock_semantic per MAO edge).
+# CURSOR_MAO_DOWNSTREAM_READINESS=0
+
+# After recording a todo-write observation, also refresh gate.json (only when CURSOR_MAO_GATE is on).
+# CURSOR_MAO_TODO_POST_TOOL_REFRESH_GATE=1
+
+# Opt-in: after handoff writes, PostToolUse may call capture_transition_decision when
+# CURSOR_MAO_GATE is on and gate.json is a trusted positive fresh preflight (no capture when gate disabled).
+# CURSOR_MAO_HOOK_AUTO_TRANSITION_CAPTURE=1
+
+# Opt-in: when hook auto-capture runs capture_transition_decision(), also POST MaoTransition to the
+# observability API (fail-open). Visibility only — does not call TodoWrite or spawn agents.
+# CURSOR_MAO_EMIT_TRANSITION_OBSERVABILITY=1
+
+# Opt-in: after record_mao_todo_write_post_tool_observation() persists locally, also POST
+# MaoTodoObservation to the observability API (fail-open). PostToolUse-derived hint only — not live
+# Cursor todo state; may be absent when todos change. Requires CURSOR_MAO_TODO_POST_TOOL_USE on.
+# CURSOR_MAO_EMIT_TODO_OBSERVATION_OBSERVABILITY=1
+
+# Opt-in: after a successful build→validate hook auto-capture, write verifier-autostart-intent.json
+# (parent-owned verifier dispatch signal only; hooks never spawn subagents).
+# CURSOR_MAO_VERIFIER_AUTOSTART=1
+# Optional stricter slice: require last-todo-write-observation.json to exist with parse_quality == ok.
+# CURSOR_MAO_VERIFIER_AUTOSTART_REQUIRE_TODO_OBSERVATION=1
+
+# Parent-only: allow scripts/mao-verifier-autostart-intent.py --delete-if-consumable to unlink intent when consumable.
+# Must be exactly 1 (ASCII). Does not enable hooks to delete or spawn agents.
+# CURSOR_MAO_PARENT_CONSUME_VERIFIER_INTENT_OK=1
+
+# Your name — used for personalized TTS announcements (~30% of the time)
+# ENGINEER_NAME=Christian
+
+# ─── API Keys ─────────────────────────────────────────────────────────────────
+
+# Anthropic API key (used by LLM utilities, event summarization, and MCP servers)
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# OpenAI API key (used by LLM utilities, TTS, and MCP servers)
+# OPENAI_API_KEY=sk-...
+
+# ElevenLabs API key (optional — for high-quality TTS announcements)
+# ELEVENLABS_API_KEY=...
+
+# ─── E2B Sandboxes (Optional — excluded from Phase 1) ────────────────────────
+
+# Required only if E2B is adopted in a future phase
+# E2B_API_KEY=e2b_...

--- a/.mat/AGENTS.mat.md
+++ b/.mat/AGENTS.mat.md
@@ -1,0 +1,532 @@
+# AGENTS.md — Cursor-First Agentic Workflow Guide
+
+This file replaces `CLAUDE.md` and any Claude-specific agent guidance files. It provides
+Cursor-native instructions for agents operating in this repository.
+
+---
+
+## Repository Purpose
+
+This repository implements a Cursor-first multi-agent engineering workflow adapted from
+IndyDevDan's (disler) Claude Code agentic patterns. The architecture uses Cursor subagents,
+hooks, worktrees, and MCP integrations instead of Claude-specific team/task-board primitives.
+It is an internal/reference-oriented repository for the maintainer team, not a public packaging target by default.
+
+When this repo is adopted into another codebase, use the sidecar helper to keep product-owned `AGENTS.md` files intact, add the short pointer note by default, and reserve the inline delimited MAT section for explicit fallback runs only. The **workflow artifact contract** for `build-result.md` / `verify-result.md` lives at `docs/workflow-artifact-contract.md` in this source repo and is packaged to **`.mat/docs/workflow-artifact-contract.md`** on bootstrap; adopted `.cursor/` prompts are rewritten to reference the sidecar path so operators are not pointed at a missing root `docs/` file.
+
+**Source vs adopted (layout honesty):** this repository is the MAT **source** tree: it ships the full `docs/` manual set, `specs/`, `apps/` (observability), the primary `tests/` regression suite, and CI-oriented checks. A **bootstrapped product repo** gets `.cursor/`, selected `scripts/` (including `phase1-verify.sh`), `.mat/docs/`, `.mat/tests/` (copies of a small contract subset), `.mat/AGENTS.mat.md`, and minimal root `docs/current-plan.md` plus `docs/long-run-state.md` — not a mirror of MAT’s entire documentation or application stack. Detection for tooling is primarily **filesystem-based** (for example `scripts/phase1-verify.sh` treats a present `.mat/README.md` as the adopted sidecar marker; optional env `MAT_REPO_LAYOUT=adopted|source` may be introduced by operators for future tooling but is not required today).
+
+For later MAT refreshes in adopted repos, prefer the `update-mat.py` dry-run → review → optional `--apply` flow; re-running `bootstrap-workflow-into-repo.sh` is a heavier full refresh from the layout manifest. **Dry-run** includes a structured **legacy cleanup preview** (same engine as apply, non-writing) in the plan JSON and stdout; **apply** and **re-bootstrap** run real **legacy migration cleanup** (`scripts/adoption/apply_mat_legacy_cleanup.py` + `mat-legacy-migrations-v1.json`) so obsolete pre-`mat-*` command files are not left beside the current bundle by default. The migration manifest is validated before runs (it must not target footprint preserve/protected paths; fingerprinted entries require `fingerprint_provenance`). Operators can re-check fingerprint unions with `scripts/adoption/mat-legacy-fingerprints.py` (`--verify-all` in `phase1-verify.sh` on source trees) and inspect audits via `apply_mat_legacy_cleanup.py --report` or `bash doctor.sh --legacy-cleanup`. Details: `docs/update-mat/architecture-and-rollout.md`, `docs/getting-started-existing-projects.md`.
+
+---
+
+## Directory Layout
+
+```
+.cursor/
+  hooks.json              # Cursor hook manifest (11 events)
+  hooks/                  # Hook scripts (Python)
+    before_submit_prompt.py   # Prompt logging/validation (beforeSubmitPrompt)
+    session_start.py          # Session init, env validation (SessionStart)
+    session_end.py            # Session completion logging (SessionEnd)
+    pre_tool_use.py           # Pre-execution validation (PreToolUse)
+    post_tool_validate.py     # Post-tool linting / type-check (PostToolUse)
+    send_event.py             # Observability event emitter (PostToolUse, Stop, SubagentStop)
+    after_file_edit.py        # Auto-format after edits (afterFileEdit)
+    post_tool_use_failure.py  # Tool failure logging (PostToolUseFailure)
+    stop_validator.py         # Wired on Stop: Phase 1 permissive checks + TTS (see Validation Policy)
+    subagent_start.py         # Subagent spawn logging (SubagentStart)
+    pre_compact.py            # Context compaction observer (PreCompact)
+    bootstrap_worktree.sh     # Worktree environment bootstrap
+    validators/               # Optional utilities — not wired on shipped `stop` (see Validation Policy)
+      validate_file_contains.py  # Optional helper: file content checks (use from a custom hooks.json if desired)
+      validate_new_file.py       # Optional helper: new-file presence checks (use from a custom hooks.json if desired)
+    utils/
+      constants.py            # Shared paths and session helpers
+      summarizer.py           # LLM-based event summarization
+      hitl.py                 # Human-in-the-loop WebSocket requests
+      llm/
+        anth.py               # Anthropic client (Haiku 4.5)
+        oai.py                # OpenAI client (GPT-4.1-nano)
+      tts/
+        elevenlabs_tts.py     # ElevenLabs Flash v2.5 TTS
+        openai_tts.py         # OpenAI gpt-4o-mini-tts
+        pyttsx3_tts.py        # Offline TTS (no API key required)
+
+  agents/                 # Cursor subagent definitions
+    parent-orchestrator.md    # Task sequencing, retry, result synthesis
+    builder.md                # Code implementation with self-validation
+    verifier.md               # Read-only validation with evidence
+    test-writer.md            # Focused test authoring and regression coverage
+    style-reviewer.md         # Documentation/style consistency and claim hygiene
+    meta-agent.md             # Agent factory — generates new agent definitions
+    scout-report-suggest.md   # Read-only codebase analysis and issue detection
+    docs-scraper.md           # Documentation fetching and saving
+    create-worktree-subagent.md  # Automated worktree creation
+    demo-agent.md             # Self-contained workflow demo
+
+  commands/               # Custom slash commands
+    mat-plan-team.md          # Multi-agent orchestrated planning
+    mat-long-run.md           # Queued multi-slice missions (long-run contract)
+    mat-plan.md               # Solo planning (simpler alternative)
+    mat-plan-onboarding.md    # Heavyweight planning package authoring
+    mat-build.md              # Builder subagent delegation
+    mat-review.md             # Verifier subagent delegation
+    mat-prime.md              # Codebase context loader
+    mat-question.md           # Read-only Q&A
+    mat-git-status.md         # Git state summary
+    mat-wt-create.md         # Create isolated worktree
+    mat-wt-list.md           # List all worktrees with status
+    mat-wt-remove.md         # Remove worktree and cleanup
+    mat-wt-check.md          # Check worktree health and collisions
+    mat-doctor.md            # Run local setup/runtime diagnostics
+    mat-start.md             # Start observability server+client
+    output-styles/
+      concise.md              # Brief bullet-point output
+      detailed.md             # Comprehensive with rationale
+      report.md               # Structured report format
+
+  skills/                 # Portable SKILL.md skill definitions
+    the-library/              # Meta-skill for private skill distribution
+    meta-skill/               # Skill creation guide
+    worktree-manager/         # Comprehensive worktree management
+    create-worktree/          # Lightweight worktree creation
+
+  worktrees.json          # Parallel agent worktree configuration
+  mcp.json                # MCP server definitions
+
+AGENTS.md                 # This file — agent guidance and validation policy
+docs/
+  README.md              # Documentation index / TOC
+  quick-start.md         # First-run setup for operators
+  getting-started-new-projects.md      # Integrate workflow into a new repo
+  getting-started-existing-projects.md # Safely retrofit an existing repo
+  components.md          # Component reference
+  configuration.md       # Env vars, hooks, worktrees, MCP config
+  data-flow.md           # Prompt → agents → outputs → observability
+  events-and-visualization.md # Hook events, payloads, and dashboard views
+  agent-teams.md         # Team composition guidelines
+  orchestration-workflow.md # Sequencing, retries, synthesis, lifecycle
+  technical-stack.md     # Runtime stack overview
+  features-demonstrated.md   # Implemented capabilities inventory
+  usage-examples-and-cases.md # Concrete usage examples
+  what-it-can-do-and-how-it-works.md # Plain-language capabilities and limits
+  best-practices.md      # Operator and integrator guidance
+  inventory.json          # Asset inventory (Stage 0)
+  migration-backlog.md    # Historical migration backlog archive
+  orchestration.md        # Orchestration design (Stage 2)
+  hooks-mapping.yaml      # Hook translation mapping (Stage 3)
+  events.yaml             # Observability event normalization spec (Stage 4)
+  artifacts-index.md      # Stage acceptance tracking
+  pilot-report.md         # Stage 6 pilot results
+  decision-record.md      # Stage 7 optional enhancement decisions
+
+apps/
+  server/                 # Bun observability server (reused from disler)
+  client/                 # Vue observability client (reused from disler)
+```
+
+---
+
+## Slash Commands
+
+Use these custom commands (available as `/command-name` in Cursor):
+
+| Command | Purpose |
+|---------|---------|
+| `/mat-plan <task>` | Lightweight solo planning — writes one file: `specs/<slug>.md` |
+| `/mat-plan-onboarding <task>` | Heavyweight planning-only onboarding — writes the four-file package under `specs/<slug>/` |
+| `/mat-plan-team <task>` | Orchestrated multi-agent planning with builder and verifier |
+| `/mat-long-run <task>` | Queued multi-slice mission with `docs/long-run-state.md` and post-slice mission gate |
+| `/mat-subagents-spawn <task>` | Decompose work and run parallel Task subagents (parent integrates results; see command doc) |
+| `/mat-build <task>` | Delegate a build task to the builder subagent |
+| `/mat-review` | Run the verifier subagent against recent changes |
+| `/mat-prime` | Load codebase context for a new session |
+| `/mat-question <question>` | Read-only Q&A about the project |
+| `/mat-git-status` | Summarize current git repository state |
+| `/mat-sprint <task>` | Execute one bounded slice with DoR, implementation, verification, and review |
+| `/mat-lite <task>` | Run a lightweight docs/config/quality pass without the full orchestration flow |
+| `/mat-update-mat <task>` | Refresh MAT-owned assets from upstream with a dry-run-first, AGENTS-safe updater |
+| `/mat-wt-create <branch>` | Create an isolated worktree (explicit `git worktree`; bootstrap writes `runtime.env` hints) |
+| `/mat-wt-list` | List all worktrees with status and configuration |
+| `/mat-wt-remove <branch>` | Remove a worktree and clean up |
+| `/mat-wt-check` | Run worktree health and collision checks |
+| `/mat-doctor` | Run local diagnostics for workflow readiness |
+| `/mat-start` | Start the observability server and client |
+
+---
+
+## Agent Roles
+
+### Parent Orchestrator (`parent-orchestrator`)
+- Owns task sequencing, retry logic, and result synthesis
+- Delegates implementation to the builder subagent
+- Delegates validation to the verifier subagent
+- Uses files, hooks, and session transcripts as durable handoff points
+- Does NOT depend on Claude task-board primitives (TaskCreate, TaskList, SendMessage)
+
+### Builder (`builder`)
+- Implements code, writes files, runs tools
+- Self-validates via PostToolUse hook (Ruff, Ty, or project linter)
+- Reports completion by producing a structured output artifact (e.g., `build-result.md`)
+
+### Verifier (`verifier`)
+- Operates in read-only mode where possible
+- Checks builder output against acceptance criteria
+- Reports pass/fail with evidence in `verify-result.md`
+- Never modifies implementation files directly
+
+### Test Writer (`test-writer`)
+- Adds or improves focused automated tests for existing behavior
+- Prioritizes deterministic regression coverage over broad rewrites
+- Reports concrete test command evidence and outcomes
+
+### Style Reviewer (`style-reviewer`)
+- Reviews docs/command/agent text for clarity and consistency
+- Aligns inventories across `README.md`, `AGENTS.md`, and `docs/components.md`
+- Removes overclaims that are not backed by shipped runtime evidence
+
+### Repo-Local Agent Contract Metadata (v1.0.0)
+
+All repo-local agents should document an explicit contract section with:
+- `contract_version` (current baseline: `1.0.0`)
+- `retry_policy` (bounded retries are parent/orchestrator owned)
+- `observability_contract` (telemetry is advisory/fail-open, not gate truth by itself)
+
+### Meta Agent (`meta-agent`)
+- Generates new agent definition files from descriptions
+- An "agent factory" — creates complete, ready-to-use agent configs
+- Writes new agents to `.cursor/agents/`
+
+### Scout (`scout-report-suggest`)
+- Read-only codebase analysis agent
+- Investigates problems, identifies root causes
+- Produces structured SCOUT REPORT with findings and suggested resolutions
+
+### Docs Scraper (`docs-scraper`)
+- Fetches documentation from URLs
+- Saves as properly formatted markdown to `ai_docs/`
+
+### Worktree Creator (`create-worktree-subagent`)
+- Automates git worktree creation via the `/mat-wt-create` command
+- Parses branch / worktree labels and runs `bootstrap_worktree.sh` with that name (observability ports come from bootstrap, not a CLI offset)
+
+### Demo Agent (`demo-agent`)
+- Self-contained demonstration of the multi-agent workflow
+- Shows hooks, validation, and observability integration
+
+### Cursor To-dos orchestration (Phase 2 MVP — shipped)
+
+**MVP slice:** Native To-dos use a strict **MAO** protocol (three tagged tasks: `[mao:plan]`, `[mao:build]`, `[mao:validate]`) documented in [`docs/todo-orchestration-protocol.md`](docs/todo-orchestration-protocol.md), enforced for composer runs via [`.cursor/rules/orchestrator-todos.mdc`](.cursor/rules/orchestrator-todos.mdc), and aligned in [`.cursor/agents/parent-orchestrator.md`](.cursor/agents/parent-orchestrator.md), builder, verifier, and `/mat-plan-team`. Parent prompts may also inject an advisory single-line `MAO_TASK_CONTEXT_JSON:` block for builder/verifier starts; `subagent_start.py` logs it when valid, resolves **`mao_worktree`** from the workspace root (`.cursor/worktree/*` bootstrap markers when present), and accepts an optional parent `mao_worktree.label` inside the JSON for cross-checking. Refreshed `artifacts/mao/gate.json` and `transition-events.jsonl` lines include the same **`mao_worktree`** shape for traceability; missing markers never block hooks. Parent-owned `plan -> build` and `build -> validate` decisions are recorded in gitignored `artifacts/mao/transition-events.jsonl` via `capture_transition_decision()` in [`mao_gate.py`](.cursor/hooks/mao_gate.py), which returns **`todo_mutations`** and embeds them on each JSONL line; when the append succeeds it also overwrites gitignored **`artifacts/mao/suggested-todo-mutation.json`**. That mirrors `parent_owned_todo_mutations_for_transition()` — the exact MAO status mutations the parent may apply when `manual_file_check` applies or when `gate_plus_files` stays aligned with a live `advisory_pending` recompute. The same module exposes `apply_parent_todo_mutations_to_cursor_todos()` and `validate_mao_todo_mutations_against_todos()` for deterministic `TodoWrite merge` from tag-prefix mutations; optional CLI [`scripts/mao-todo-write-merge.py`](scripts/mao-todo-write-merge.py). Hooks do **not** call `TodoWrite`. `evaluate_*_transition()` attaches that explicit `advisory_pending` bundle for orchestration summaries. `artifacts/mao/gate.json` may also describe still-`pending` downstream work as `blocked` or `ready_for_parent_review`, but that advisory metadata never changes the real Cursor todo status on its own. **File handoffs remain authoritative**; if `TodoWrite` is unavailable or task context is missing/malformed, use files only and note the skip in `docs/session-summary.md`. When execution is based on an approved onboarding package, the parent must also keep the matching `TASK-###` entry in `specs/<slug>/tasks.json` synchronized with the active slice so progress stays honest without creating a second runtime system. Optional routing/cost telemetry may also be summarized into `artifacts/mao/routing_rollup_<session_id>.json` and inspected with `scripts/analyze_routing_advisory.py`; prompt lint warnings write `artifacts/mao/prompt_lint_<session_id>.log`; session budget notes may append to `docs/session-summary.md` when `CURSOR_MAT_SESSION_BUDGET_USD` is set and the best-effort estimate exceeds the threshold; all of it stays advisory only.
+
+**Wait-before-supersede discipline:** After the parent spawns the builder or verifier, allow a reasonable startup window before treating silence as a stall. Legitimate startup includes repo reads/searches, environment or setup checks, validation output, transcript growth, and partial artifacts. Distinguish normal startup, active progress, unclear state, and true stall/failure: only the last one justifies overlap or takeover. The parent may do other **non-overlapping** orchestration work while waiting, but must not duplicate the same implementation or review work in parallel. Before intervening, check for progress signals such as subagent updates, changed files, validation output, or partial artifact creation. If status is unclear, **resume the same subagent first** with a narrow status follow-up. If the tree is dirty, inspect it with `scripts/inspect_worktree_attribution.py` before declaring any modified file unexpected. Only re-spawn, replace, or supersede a subagent when there is clear evidence of failure, deadlock, or repeated non-progress after a reasonable wait.
+
+**Pilot:** [`docs/todo-orchestration-pilot.md`](docs/todo-orchestration-pilot.md).
+
+**Hooks:** `PostToolUse` still runs `send_event.py` and `post_tool_validate.py`; when a file-writing tool touches `docs/current-plan.md` or `build-result.md`, `post_tool_validate.py` also refreshes gitignored **`artifacts/mao/gate.json`** via [`mao_gate.py`](.cursor/hooks/mao_gate.py) (`build_may_start`, stricter `validate_may_start`, and `advisory_pending` hints; disable with `CURSOR_MAO_GATE=0`). The parent may consume that file only as a **fresh, valid, internally consistent, positive** advisory signal before the explicit parent-owned transition checks: `plan -> build` (`current-plan` ready) and `build -> validate` (`current-plan` ready, build status PASS/PARTIAL, `Acceptance Criteria` with no FAIL, `Linting / Type-Check` PASS). `ready_for_parent_review` in `advisory_pending` is only a description of a still-`pending` downstream todo, not a replacement for `in_progress`. Those explicit checks can also be durably recorded in gitignored **`artifacts/mao/transition-events.jsonl`** (including the `advisory_pending` bundle), and `parent_owned_todo_mutations_for_transition()` returns the exact helper-driven status updates for any passing parent-owned transition decision on the manual/file path or on `gate_plus_files` when `advisory_pending` from the gate file matches the live recompute; misaligned trusted gate + file snapshots yield **no** helper-driven mutation even if canonical files look ready. File handoffs remain canonical and neither capture path may auto-start the builder or verifier. Todo tools are not file-writers, so `post_tool_validate.py` does not run project lint on todo updates (see protocol doc). **`failClosed` is false** — acceptable blocking risk for this spike.
+
+**PostToolUse MAO todo observation (narrow slice):** After a `TodoWrite` tool completes, [`post_tool_validate.py`](.cursor/hooks/post_tool_validate.py) may append **`artifacts/mao/todo-write-events.jsonl`** and overwrite **`artifacts/mao/last-todo-write-observation.json`** via [`record_mao_todo_write_post_tool_observation()`](.cursor/hooks/mao_gate.py) (parsed MAO tags when unambiguous, `mao_worktree`, **`file_handoff_signals`** from handoff files — advisory only). Hooks still do **not** call `TodoWrite`. Disable with `CURSOR_MAO_TODO_POST_TOOL_USE=0`. Optional `CURSOR_MAO_TODO_POST_TOOL_REFRESH_GATE=1` refreshes `gate.json` when `CURSOR_MAO_GATE` is on.
+
+**MAO downstream readiness snapshot (narrow slice):** After `gate.json` refresh, after a successful todo-write observation, after a successful `capture_transition_decision()` JSONL append (`trigger: transition_capture` or `hook_post_tool_use_auto_capture` for opt-in hook capture), or when handoff files change with `CURSOR_MAO_GATE=0`, [`mao_gate.py`](.cursor/hooks/mao_gate.py) may overwrite gitignored **`artifacts/mao/downstream-readiness.json`** with deterministic per-edge **`unblock_semantic`** (same rules as `parent_owned_todo_mutations_for_transition()`), plus optional **`todo_write_cross_check`** vs `last-todo-write-observation.json`. Advisory only — parent still runs explicit transition checks and applies `TodoWrite`. Disable hook writes with `CURSOR_MAO_DOWNSTREAM_READINESS=0`. **Parent consumption:** [`evaluate_parent_downstream_readiness_advisory()`](.cursor/hooks/mao_gate.py) (or [`scripts/mao-downstream-readiness.py`](scripts/mao-downstream-readiness.py), `--interpret-edges`) returns **`live_snapshot`** always and **`trusted_snapshot_for_hint`** only when the on-disk file’s edges match live; stale/missing/invalid data falls back to live semantics — never a substitute for canonical handoff checks.
+
+**MAO parent transition bundle (2026-03-27):** [`evaluate_mao_parent_transition_bundle()`](.cursor/hooks/mao_gate.py) returns one dict: transition `decision`, `todo_mutations`, `edge_readiness`, [`interpret_unblock_semantic_for_parent()`](.cursor/hooks/mao_gate.py) (all four canonical `unblock_semantic` strings), `orchestration_flow_hint`, and optional embedded full readiness advisory. [`scripts/mao-capture-transition.py`](scripts/mao-capture-transition.py) adds `--bundle-only` and embeds `parent_transition_bundle` on normal capture; `--with-downstream-readiness` nests the advisory inside that bundle; `--show-hook-flags` prints opt-in hook automation env toggles. Still no hook `TodoWrite`, no auto-spawn.
+
+**MAO hook auto-capture + verifier intent (2026-03-27):** Opt-in **`CURSOR_MAO_HOOK_AUTO_TRANSITION_CAPTURE`** runs [`maybe_hook_auto_capture_transition()`](.cursor/hooks/mao_gate.py) from [`post_tool_validate.py`](.cursor/hooks/post_tool_validate.py) after gate refresh on handoff writes; requires **`CURSOR_MAO_GATE` on**, trusted positive fresh gate, non-empty `todo_mutations`, and dedupes JSONL by transition + handoff mtimes. Opt-in **`CURSOR_MAO_VERIFIER_AUTOSTART`** may write gitignored **`verifier-autostart-intent.json`** only after a successful build→validate hook capture plus strict checks; optional **`CURSOR_MAO_VERIFIER_AUTOSTART_REQUIRE_TODO_OBSERVATION`**. Parent still owns verifier spawn and should delete or consume the intent after dispatch. Hooks never call `TodoWrite` or start subagents. **Parent consumption (shipped):** [`evaluate_verifier_autostart_intent()`](.cursor/hooks/mao_gate.py), [`delete_verifier_autostart_intent()`](.cursor/hooks/mao_gate.py), and CLI [`scripts/mao-verifier-autostart-intent.py`](scripts/mao-verifier-autostart-intent.py) (optional `--delete-if-consumable` requires **`CURSOR_MAO_PARENT_CONSUME_VERIFIER_INTENT_OK=1`** exactly).
+
+**MAO observability dashboard slice (2026-03-27):** Vue **MAO visibility** panel lists ingested **`MaoTransition`** events and a **mixed-source observed summary** (`deriveMaoObservedSnapshot`): newest row in the window, optional newest row that still has **`advisory_pending.live`** edge lanes (with a staleness banner when a newer row omits them), and latest-by-name `plan_to_build` / `build_to_validate` markers — not a coherent single snapshot and not a Cursor todo column. Bun `toWire()` uses a larger WebSocket payload preview for **`MaoTransition`** and **`MaoTodoObservation`**. Opt-in **`CURSOR_MAO_EMIT_TRANSITION_OBSERVABILITY`** adds fail-open POST from hook auto-capture’s `capture_transition_decision()`; opt-in **`CURSOR_MAO_EMIT_TODO_OBSERVATION_OBSERVABILITY`** adds fail-open **`MaoTodoObservation`** from todo-write PostToolUse observation — PostToolUse-derived hints only, not live Cursor todos; visibility only; files and parent checks stay canonical ([`docs/todo-orchestration-protocol.md`](docs/todo-orchestration-protocol.md)).
+
+**Next (beyond observation, gate file, advisory task context, worktree metadata, capture-time mutation surfacing, parent merge helpers, downstream readiness snapshot, parent bundle, capture-time readiness refresh, opt-in hook capture, verifier intent file, and parent intent evaluation/CLI):** a live dashboard todo column and hook-driven **subagent auto-spawn from live todo state** remain blocked — see [`docs/decision-record.md`](docs/decision-record.md) and [`ROADMAP.md`](ROADMAP.md). Advisory hook-written autostart intents do not imply live authoritative MAO todo parity.
+
+---
+
+## Validation Policy
+
+Every agent run should produce:
+1. A structured output artifact (`*-result.md` or equivalent)
+2. A pass/fail gate result recorded in `docs/artifacts-index.md`
+3. Hook-emitted events visible in the observability dashboard (when running)
+
+### Wired `stop` behavior vs `validators/` utilities
+
+- **Shipped `stop` (`.cursor/hooks.json`):** only `send_event.py` then `stop_validator.py`, with `failClosed` false. Nothing else runs on `stop` in the repo-default manifest.
+- **`stop_validator.py` (Phase 1, permissive):** for orchestration-style sessions it may **warn** on stderr when `docs/current-plan.md` exists but expected handoff artifacts are incomplete; when no hard-failure path applies, `missing` stays empty and the process exits **0** (warnings are advisory, not a repo-default hard block from that script today).
+- **`.cursor/hooks/validators/*.py`:** optional helper scripts. They are **not** additional commands on the shipped `stop` array. Operators may reference them from a **custom** `hooks.json` or other automation; do not treat them as independently wired stop enforcement in this repository.
+
+### Stop Conditions
+An agent MUST stop and report failure if:
+- A binary acceptance gate fails
+- A critical dependency is unavailable (e.g., missing env var, failed tool)
+- The `loop_limit` for a hook is reached without resolution
+
+---
+
+## Hook Behavior
+
+Hooks are defined in `.cursor/hooks.json`. Full event coverage:
+
+| Event | Purpose | Script(s) |
+|-------|---------|-----------|
+| `beforeSubmitPrompt` | Prompt logging/validation | `before_submit_prompt.py` |
+| `sessionStart` | Environment validation, session init event | `session_start.py` |
+| `sessionEnd` | Session completion logging, statistics | `session_end.py` |
+| `preToolUse` | Optional tool blocking, pre-execution logging | `pre_tool_use.py` |
+| `postToolUse` | Linting, type-check, observability event | `send_event.py`, `post_tool_validate.py` |
+| `afterFileEdit` | Auto-format after file edits | `after_file_edit.py` |
+| `postToolUseFailure` | Tool failure logging for debugging | `post_tool_use_failure.py` |
+| `stop` | Stop-loop self-validation, TTS notification | `send_event.py`, `stop_validator.py` |
+| `subagentStart` | Subagent lifecycle logging | `subagent_start.py` |
+| `subagentStop` | Subagent lifecycle event | `send_event.py` |
+| `preCompact` | Context compaction observer, transcript backup | `pre_compact.py` |
+
+**Notes:**
+- `preToolUse`: `pre_tool_use.py` resolves `tool_name` vs `tool` via `resolve_tool_name()` (unit-tested in `tests/test_phase1_hooks.py`); default blocking list is empty (`failClosed` is false in `hooks.json`).
+- `loop_limit` is set per hook in `hooks.json`. Do not bypass hook failures
+  by force-exiting — report the failure and let the parent agent decide on retry.
+- Claude's `Notification` hook is replaced by `Stop` + `SubagentStop` hooks with
+  macOS desktop notifications in `stop_validator.py`.
+- Claude's `PermissionRequest` hook has no direct Cursor equivalent — permission
+  handling is built into Cursor's agent runtime.
+
+---
+
+## Utilities
+
+### LLM Clients
+- `utils/llm/anth.py` — Anthropic Haiku 4.5 for fast completions and agent naming
+- `utils/llm/oai.py` — OpenAI GPT-4.1-nano for fast completions
+- Used by hooks for generating event summaries and completion messages
+
+### TTS System
+- Priority order: ElevenLabs > OpenAI > pyttsx3 (offline fallback)
+- Controlled by `--notify` flags on `stop_validator.py` and `session_end.py`
+- Requires `ELEVENLABS_API_KEY` or `OPENAI_API_KEY` for cloud TTS
+
+### Human-in-the-Loop (HITL)
+- WebSocket-based interactive decision system via `utils/hitl.py`
+- Sends questions/choices to the observability dashboard for human response
+- Used for permission prompts, choices, and interactive agent decisions
+
+### Event Summarization
+- `utils/summarizer.py` uses the Anthropic client to generate one-sentence event summaries
+- Enriches observability events with human-readable descriptions
+
+---
+
+## Worktree Usage
+
+When running parallel agents in **separate directories**, treat worktrees as **explicit** git isolation (Cursor 3: use `/worktree`, `/best-of-n`, or manual `git worktree add` — the editor does not silently create a new git worktree per parallel agent). After a worktree exists, **bootstrap** (`.cursor/hooks/bootstrap_worktree.sh`) may run via `.cursor/worktrees.json` setup keys or manually; it copies `.env` when missing, installs deps, and writes `.cursor/worktree/runtime.env` with collision-aware `OBSERVABILITY_PORT` / `OBSERVABILITY_CLIENT_PORT` hints (`3001`/`5173` bases + `cksum(name) mod 200`, then `pick_free_port`).
+
+Typical MAT posture: builder and verifier **can** operate in separate worktrees when you create them; that is orchestration and operator choice, not an automatic Cursor guarantee.
+
+**LSP caveat:** Worktrees may not have full LSP support (linting/type feedback). Run
+explicit linting via hook scripts (`post_tool_validate.py`) rather than relying on
+editor-integrated feedback inside the worktree.
+
+### Worktree Management Commands
+- `/mat-wt-create <branch>` — create/configure an isolated worktree; see command doc for bootstrap + `runtime.env`
+- `/mat-wt-list` — view worktrees; prefer `.cursor/worktree/runtime.env` per tree for observability port hints
+- `/mat-wt-remove <branch>` — stop services, remove worktree and branch
+- `/mat-wt-check` — check local worktree health and collisions
+- `/mat-doctor` — run repo diagnostics (`scripts/doctor.sh`)
+
+---
+
+## Observability
+
+The observability stack (Bun server + SQLite + Vue dashboard) receives events via
+`.cursor/hooks/send_event.py` on every `PostToolUse`, `Stop`, and `SubagentStop` event.
+
+To start the API and dashboard together (recommended):
+```bash
+bash scripts/start-system.sh
+```
+
+Or start them separately after `bun install` in each app:
+
+```bash
+cd apps/server && bun run dev
+# other terminal:
+cd apps/client && bun run dev
+```
+
+Or use the `/mat-start` command, which runs `bash scripts/start-system.sh`.
+
+Events are normalized via the adapter in `apps/server/src/adapter.ts` before
+persisting to SQLite.
+
+## Documentation Map
+
+Use `docs/README.md` as the primary documentation entrypoint.
+
+Recommended reading order:
+1. `README.md`
+2. `docs/quick-start.md`
+3. `docs/what-it-can-do-and-how-it-works.md`
+4. `docs/configuration.md`
+5. `docs/agent-teams.md` and `docs/orchestration-workflow.md`
+6. `docs/usage-examples-and-cases.md`
+
+---
+
+## Project-first capability routing
+
+MAT expects **project-local** `.cursor/` assets and root `AGENTS.md` to take **precedence** over global and plugin defaults for **repo-specific** workflow behavior, while MAT orchestration stays **additive** and file-handoff-centric. See [`docs/capability-precedence.md`](docs/capability-precedence.md) for the full precedence stack, discovery conventions, conflict rule, and what remains **authoritative** (`docs/current-plan.md`, `build-result.md`, `verify-result.md`) versus **advisory** (hooks, gates, routing hints).
+
+In downstream repos, keep root and nested `AGENTS.md` files product-owned. Put the MAT encyclopedia in `.mat/AGENTS.mat.md`, and add only a short pointer note in each `AGENTS.md` by default; reserve the inline MAT section for an explicit exception.
+
+For MAT's conservative model-tier policy, see [`docs/model-routing-policy.md`](docs/model-routing-policy.md); keep that policy docs-first, adapter-agnostic, and separate from any future `agent-model-router` boundary.
+
+For **bounded context** and artifact-first loading (avoid habitual mega-docs and transcript replay), see [`docs/context-budget-policy.md`](docs/context-budget-policy.md).
+
+## Cost & context hygiene (enforced pack)
+
+This repository ships a **default low-token posture**: always-on [`.cursor/rules/cost-context-hygiene.mdc`](.cursor/rules/cost-context-hygiene.mdc), root [`.cursorignore`](.cursorignore) aligned with the MAT template set under [`docs/templates/`](docs/templates/) (see `cursorignore-mat-default` and stack variants: `node`, `python`, `wordpress`, `rails`), and CI checks in [`scripts/validate_cost_context_hygiene_pack.py`](scripts/validate_cost_context_hygiene_pack.py) (invoked from `scripts/phase1-verify.sh` with `--enforce auto` — for this source repo, **strict** in practice). The rule includes the honest UI boundary: MAT **cannot block** `@Codebase` or other broad Cursor context controls in the product — strictness is rules, CI, and operator discipline.
+
+`python3 scripts/validate_cost_context_hygiene_pack.py --report --no-fail` and `bash scripts/doctor.sh --cost-hygiene` are non-fatal diagnostic paths. Adopted **existing-project** runs record `warn_first` in `.mat/cost-hygiene-adoption.json` and never overwrite an existing product `.cursorignore`; when root `.cursorignore` is absent, bootstrap installs the MAT template (same as new-project). Optional **`CURSOR_MAT_COST_HYGIENE_ENFORCE`** in CI can force `strict` until ignore fragments are merged. Local JSON under `artifacts/cost-hygiene/` is **advisory only** (not billing, not a token account).
+
+**Optional submit-time guardrails:** See [`docs/MAINTAINER.md`](docs/MAINTAINER.md#submit-time-prompt-validation-opt-in) for `CURSOR_VALIDATE_PROMPTS`, how [`before_submit_prompt.py`](.cursor/hooks/before_submit_prompt.py) evaluates blocked patterns, the empty in-repo default list, and false-positive risk.
+
+---
+
+## Maintaining the roadmap
+
+The canonical product and engineering roadmap is **[`ROADMAP.md`](ROADMAP.md)** at the repository root (repo: [Devora-AS/multi-agent-workflow](https://github.com/Devora-AS/multi-agent-workflow)). Keep it **current during development** so operators and agents share one source of truth.
+
+### When to update
+
+- **Starting** work that matches a roadmap theme (or adding a new theme): place or adjust the item under **Now**, **Next**, or **Later**; use the legend tags ([Done], [Planned], [Deferred], [Idea]).
+- **Shipping** a feature that corresponds to a roadmap checkbox: mark the box **`[x]`** in the same PR (or immediately after merge), and bump the **Last updated** date at the top of `ROADMAP.md`.
+- **Closing out** shipped or guidance-visible work: keep `README.md`, `AGENTS.md`, `CHANGELOG.md`, `ROADMAP.md`, and related docs synchronized whenever the slice changes shipped behavior or operator guidance.
+- **Deferring or dropping** scope: move the item to **Later**, tag **[Deferred]** or **[Idea]**, and add a one-line rationale so history is clear.
+- **Borrowing-pattern detail** (full matrices): add or edit rows in the **Appendix** of `ROADMAP.md`; keep section bullets short and milestone-focused—one canonical checkbox per deliverable.
+
+### GitHub Issues (optional, recommended when the team adopts them)
+
+- **Tracking:** You may link a roadmap checkbox to an issue for clearer “done” semantics, e.g. `- [ ] Ship feature X ([#42](https://github.com/Devora-AS/multi-agent-workflow/issues/42))`.
+- **Workflow:** Prefer **create the issue first**, then add the link next to the checkbox (or create the issue from the PR and back-link). Close the issue when the checkbox is marked done.
+- **Avoid duplication:** Do not maintain the same work as both an unlinked vague bullet and a separate issue with no cross-reference—pick one canonical line in `ROADMAP.md` and link out.
+- **Not required:** The roadmap can use checkboxes alone until you choose to enable issue tracking.
+
+### What stays outside the roadmap
+
+- **Staged migration / gate artifacts** — still recorded in [`docs/artifacts-index.md`](docs/artifacts-index.md) (branch, SHA, reviewer, acceptance).
+- **Optional enhancement go/no-go** — still governed by [`docs/decision-record.md`](docs/decision-record.md).
+- **Deep specs** — link from `ROADMAP.md` into `docs/` instead of pasting long prose into the roadmap file.
+
+### Agent and contributor checklist
+
+- [ ] Roadmap **Vision / Current Focus / Near-Term / Recently Completed / Future Concepts / Icebox / Blocked** reflects the change you are making (or you added a new item explicitly).
+- [ ] **Last updated** in `ROADMAP.md` changed when the file changed.
+- [ ] `README.md`, `AGENTS.md`, `CHANGELOG.md`, `ROADMAP.md`, and related docs were refreshed when the slice changed shipped behavior or operator guidance.
+- [ ] Linked **GitHub issue** (if any) matches the checkbox and is referenced from the PR description.
+- [ ] [`docs/artifacts-index.md`](docs/artifacts-index.md) updated when a **staged artifact** or gate result is part of the work.
+
+### Inventory hygiene (rules and skills)
+
+When you add or materially change a **repo-local** surface under `.cursor/rules/` or `.cursor/skills/`:
+
+- Add or update a discoverability row in **this file** (slash commands table, skills list, or hooks section as appropriate).
+- Refresh [`docs/components.md`](docs/components.md) and [`README.md`](README.md) when operators need to find the surface without reading the whole tree.
+- If the surface changes adoption or verification behavior, also update [`docs/MAINTAINER.md`](docs/MAINTAINER.md) and [`CHANGELOG.md`](CHANGELOG.md).
+- Do not rely on plugin-only or global defaults as the only documentation for MAT-shipped operator workflows.
+
+---
+
+## Cloud Agents
+
+For stronger isolation than local worktrees (no filesystem conflicts, fresh VM):
+
+- Use the **Agents Window** (Cursor 3 agent-first surface) and choose **cloud**, **SSH**, or **multi-workspace** as needed — not editor Settings as the sole setup path.
+- Configure cloud agents with [`.cursor/environment.json`](.cursor/environment.json) (`install` / `start` lifecycle) or web onboarding; see [cursor.com/docs/cloud-agent](https://cursor.com/docs/cloud-agent) and [cursor.com/docs/agent/agents-window](https://cursor.com/docs/agent/agents-window).
+- Cloud agents run in isolated VMs with computer-use capabilities when enabled.
+- They read MCP integrations from `.cursor/mcp.json` and guidance from root `AGENTS.md`.
+- Prefer cloud agents for long-running or resource-intensive subagent tasks.
+- **MAT does not auto-provision cloud agents** — operators configure cloud via the Agents Window and environment file; file handoffs (`docs/current-plan.md`, `build-result.md`, `verify-result.md`) stay authoritative. See [`docs/decision-record.md`](docs/decision-record.md#p1-audit--cloud-agents-agents-window).
+
+---
+
+## Environment Variables
+
+Copy `.env.sample` to `.env` and fill in required values before running agents:
+
+```bash
+cp .env.sample .env
+```
+
+Required variables are documented in `.env.sample`.
+
+### Bun on `PATH`
+
+The official installer places the binary at `~/.bun/bin/bun`. Interactive shells pick that up from `~/.zshrc`, but **Cursor agent terminals and non-interactive automation often do not**. This repository:
+
+- Sources `scripts/lib/ensure-bun-path.sh` from `scripts/start-system.sh` and `scripts/phase1-verify.sh` so `bun` is discoverable when it exists under `~/.bun/bin` or `BUN_INSTALL`.
+- Ships **`.vscode/settings.json`** workspace defaults so the **integrated terminal** prepends `~/.bun/bin` (macOS/Linux) or `%USERPROFILE%\.bun\bin` (Windows) to `PATH`.
+
+Prefer `bash scripts/start-system.sh` from the repository root to start the observability server in any environment.
+
+---
+
+## Learned User Preferences
+
+- For multi-agent orchestration and related roadmap work, treat **Cursor To-dos** plus **Cursor Hooks (v1.7+)** as the intended shared state and handoff mechanism; do not reference or recommend Taskmaster AI in documentation, plans, or suggestions.
+- For new projects or substantive new features, start with clarifying questions and PRD-style requirements and planning (for example `/mat-plan` for lightweight work or `/mat-plan-onboarding` for heavier discovery/traceability) before implementation; use explicit planning or deeper reasoning when scope is ambiguous rather than jumping straight to code.
+- When scope is unclear or the answer lives on disk (capture folders, lifecycle JSON, large repo dumps), confirm enumeration scope first or read those paths directly instead of asking the user to restate what is already there.
+- When adopting or refreshing MAT in **external product repos**, prefer `update-mat.py` dry-run → review → optional `--apply`, keep product-owned `AGENTS.md` intact via the sidecar, and document **opt-in** observability plus manual SQLite rotation in the product repo — do not enable upstream auto-retention/redaction defaults from the MAT source tree.
+- For README and other repo documentation, reference images and assets with paths relative to the repository root (and check assets into the repo) instead of machine-local absolute paths (for example under `.cursor/projects/...`).
+- For roadmap, closeout, and strategy docs, keep framing aligned to this repository's internal/reference-oriented team use; avoid public-release, packaging, or publication language unless explicitly requested.
+- Do not create GitHub Issues for roadmap items unless the user explicitly asks; they may want to review the roadmap and attach issue links themselves before any backlog is created.
+- Do not `git push` to remotes unless the user explicitly asks; closeout and slice handoffs should end with a local commit and a confirmed working tree state.
+- For explicit **multi-slice** missions (several roadmap slices in one session), prefer **`/mat-long-run`** with [`docs/long-run-state.md`](docs/long-run-state.md) and the parent **post-slice mission gate**; continue with the next slice after each verified slice unless blocked or a classified stop reason applies. Do not end the run after the first slice when the user defined that multi-slice mission. `/mat-plan-team` alone is one orchestration cycle unless paired with the long-run contract.
+- For implementation slices that depend on an approved planning or spec package, materialize that package as tracked repository files first and treat those files as the canonical source of truth for the rest of the slice.
+- Treat continual-learning `AGENTS.md` edits as intentional memory maintenance when the audit/state trail points to that flow; prefer a fresh maintenance session when safe, otherwise queue updates; keep learned bullets bounded (see [`docs/continual-learning-safe-handling.md`](docs/continual-learning-safe-handling.md)).
+- For MAT audit and RFU remediation slices, prefer **`/mat-plan-team`** with **builder_plus_verifier** Task delegation (not inline-only parent implementation); include CI hardening in the same slice when touching `apps/client` rather than deferring.
+
+---
+
+## Durable Repo Facts
+
+- MAT audit remediation is **complete** on `main` (2026-06-23): P0 contract hardening, Phase A (P2), Phase B (P1), Phase C RFU C1–C5 (**RFU-7** code deferred), MAT updater slices 1–3 plus `scripts/demo/updater-operator-walkthrough.sh`; see `artifacts/report/mat-audit-report.md` and `docs/decision-record.md`.
+- RFU-7 observability retention/redaction **code** is **deferred** (2026-06-23) per `docs/decision-record.md#phase-c-rfu-7--observability-retention-and-hook-redaction-deferred`: localhost-only dashboard posture, manual `events.sqlite` rotation, no shipped auto-TTL or default-on hook redaction in the MAT source repo; adopted repos need opt-in observability guidance, not upstream auto-purge defaults.
+- `docs/adoption-observability-appendix.md` packages to `.mat/docs/` via `scripts/adoption/adoption-layout-v1.json`; disposable pilot PASS at `artifacts/report/adoption-observability-pilot-2026-06-23.md` with operator-doc cross-links and `MatAdoptionObservabilityAppendixTest`.
+- Hook capture hygiene: `payload_capture.py` must stay tracked; if `ruff` is missing or times out, `post_tool_validate.py` skips Python lint with `lint_ok` true (align `build-result.md` reporting); `get_changed_files()` supports alternate write-tool payload shapes; `subagent_start.repo_root_from_hook_payload()` matches `post_tool_validate.PROJECT_DIR`.
+- `artifacts/mat-runtime/` holds the local MAT runtime SQLite store and stays ignored; `scripts/mat-runtime.py` is the supported inspection entrypoint; `apps/server/src/runtime-review.ts` and `apps/client/src/components/RuntimeReviewPanel.vue` expose an advisory review surface subordinate to tracked handoff files.
+- `bash scripts/start-system.sh` picks free TCP ports when defaults are in use; `bash scripts/phase1-verify.sh` runs server Bun smoke plus `apps/client` `bun install --frozen-lockfile`, type-check, `test:vitest`, and build (`PHASE1_VERIFY_SKIP_CLIENT=1` skips client; GitHub Actions pins Node 22 and uses `fetch-depth: 0` for legacy fingerprint checks).
+- Shared docs contract tests (`tests/test_workflow_docs.py`, `tests/test_phase2_blocked_closeout_docs.py`, `tests/test_migration_backlog_docs.py`) assert required substrings across `README.md`, `ROADMAP.md`, `AGENTS.md`, and `docs/README.md`; substantive doc rewrites should update those tests and pass `bash scripts/phase1-verify.sh`.
+- For MAO build→validate preflight, `build-result.md` `## Acceptance Criteria` rows must be bullet lines that include an explicit `: PASS`, `: PARTIAL`, or `: FAIL` substring; unresolved checklist-only rows may not count as resolved criteria.
+- Keep `docs/templates/spec-template.md`, `docs/templates/prd-template.md`, and `docs/templates/tasks-schema.json` aligned on traceability identifiers (for example stable `SPEC-###` references) so machine-readable `tasks.json` can link to spec sections without ambiguity.
+- `/mat-plan-onboarding` must surface unresolved questions from `specs/<slug>/prd.md`, `specs/<slug>/spec.md`, and `specs/<slug>/plan-summary.md` in chat one at a time before approval, while keeping the artifacts canonical and updating question status after each answer or deferment.
+- `docs/capability-precedence.md` defines MAT's project-first routing policy only; keep it explicit that Cursor's actual Agent rules precedence is `Team Rules -> Project Rules -> User Rules`, while MAT guidance is advisory for IDE/runtime behavior and canonical handoff files remain authoritative.
+- Orchestration honesty: optional routing/cost telemetry may append to `artifacts/mao/routing-advisory.jsonl` (advisory only); when `/mat-plan-team` runs inline, closeout must say so and not imply builder/verifier proof without trace evidence; default parent prompts to copy-pasteable fenced `txt` blocks; use [`docs/orchestration-workflow.md#execution-closeout-contract`](docs/orchestration-workflow.md#execution-closeout-contract) for closeout.
+
+## Workspace-Local Operational Facts
+
+- Hook payload capture honors `CURSOR_HOOK_CAPTURE_DIR`: non-absolute paths resolve from the repository root, while leading `/` paths are filesystem-absolute. Use at most one `CURSOR_HOOK_CAPTURE_DIR` assignment in `.env`; duplicate keys are invalid.
+- For lifecycle hook verification, compare `conversation_id` across `sessionStart.json`, `stop.json`, `preCompact.json`, and `sessionEnd.json` inside the same capture folder (usually the per-session subdirectory when `CURSOR_HOOK_CAPTURE_PER_SESSION=1`).
+- Composer transcript JSONL is often chat-only, and observability `hook_events` may omit todo-tool rows in some Cursor builds; do not rely on those sources alone to prove MAO todo order when higher-fidelity local capture exists.
+- When confirming a clean working tree from automation, prefer `git status --porcelain` or raw subprocess capture; some wrappers collapse empty `git status --short` output to the literal string `ok`.
+- In `tests/test_phase1_hooks.py`, assertions involving `workspace_roots` should clear `CURSOR_PROJECT_DIR` and `CLAUDE_PROJECT_DIR` and compare canonicalized real paths so macOS `/tmp` versus `/private/tmp` symlink behavior does not create flaky failures.
+- `docs/session-summary.md` and per-run trace trees under `artifacts/agent-traces/<run-id>/` are local by default; workspace search or glob can miss gitignored paths, so read the known path directly when validating local evidence.
+
+## Dated Evidence References
+
+- `docs/todo-orchestration-pilot.md` is the dated pilot checklist for the MAO todo workflow.
+- `docs/pilot-report.md` is the dated Stage 6 pilot report and evidence template.
+- `docs/todo-orchestration-runtime-evidence.md` records dated runtime-proof expectations and audit notes for todo evidence.
+- `docs/mao-advisory-go-criteria.md` and `docs/phase4-roadmap-reassessment-checklist.md` are operator-owned reassessment references for blocked MAO/runtime claims.
+
+---
+
+## Migration Notes (for contributors)
+
+- All Claude-specific paths (`.claude/`) have been migrated to `.cursor/`
+- `CLAUDE.md` → `AGENTS.md` (this file)
+- `.claude/settings.json` → `.cursor/hooks.json`
+- `.claude/agents/` → `.cursor/agents/`
+- `.claude/commands/` → `.cursor/commands/`
+- `.claude/skills/` → `.cursor/skills/`
+- `.claude/hooks/` → `.cursor/hooks/`
+- `.mcp.json` → `.cursor/mcp.json`
+
+Claude agent frontmatter has been replaced with Cursor-native agent conventions.
+Claude team/task-board primitives (TaskCreate, TaskList, SendMessage) are replaced
+by parent-agent orchestration using files and hooks as handoff points.

--- a/.mat/README.md
+++ b/.mat/README.md
@@ -1,0 +1,14 @@
+# `.mat/` — Multi-agent workflow (MAT) sidecar
+
+This directory holds **MAT-packaged** material for this repository: reference documentation and workflow contract tests copied from the MAT source repo. It keeps product documentation at the repo root separate from workflow manuals.
+
+- **`.mat/docs/`** — packaged workflow documentation (components, getting started, MAO protocol, [workflow-artifact-contract.md](docs/workflow-artifact-contract.md) for `build-result.md` / `verify-result.md` section contracts, etc.).
+- **`.mat/tests/`** — workflow contract tests (`unittest`); run with `python3 -m unittest discover -s .mat/tests -p 'test_*.py' -v`.
+- **`.mat/AGENTS.mat.md`** — full MAT operator reference from the source `AGENTS.md`.
+- **`.mat/vendor/README-MAT.md`** — optional attribution copy of the MAT source `README.md`.
+
+Entrypoints at repo root: **`scripts/phase1-verify.sh`**, **`.cursor/`** (hooks, commands, agents).
+
+`phase1-verify.sh` detects this sidecar (presence of this file) and then: validates workflow markdown with **optional** `build-result.md` / `verify-result.md` when those handoffs are absent, skips closeout posture checks until `artifacts/agent-traces/comparison.json` exists, runs **`python3 -m unittest discover -s .mat/tests`** (not the product’s `tests/` tree), and skips the Bun observability smoke when `apps/server` is not packaged.
+
+For product narrative, use the root **`README.md`** and your application docs — not this tree.

--- a/.mat/cost-hygiene-adoption.json
+++ b/.mat/cost-hygiene-adoption.json
@@ -1,0 +1,11 @@
+{
+  "bootstrap_mode": "existing-project",
+  "detection_reason": "No strong stack markers; using generic MAT default template.",
+  "detection_signals": {},
+  "enforcement": "warn_first",
+  "root_cursorignore_created": true,
+  "root_cursorignore_preserved": false,
+  "schema_version": 1,
+  "selected_template": "default",
+  "sidecar_suggest_writable": true
+}

--- a/.mat/docs/README.md
+++ b/.mat/docs/README.md
@@ -1,0 +1,106 @@
+# Multi-Agent Teams Docs
+
+Purpose: Table of contents and entry point for the Cursor-native multi-agent workflow documentation.
+Audience: Developers, integrators, and operators adopting this workflow in Cursor.
+Prerequisites: Familiarity with Cursor, Git, shell commands, and basic LLM API setup.
+Status: complete
+Last updated: 2026-04-20
+Author: Cursor agent (GPT-5.4)
+
+## Overview
+
+This docs set explains how the repository's Cursor-first multi-agent workflow is structured, configured, operated, and validated. It complements the root-level [README](../README.md) and the agent-focused [AGENTS.md](../AGENTS.md) with operator and integrator documentation. For **worktrees**, treat **Cursor 3** as explicit isolation (`/worktree`, `/best-of-n`, or `git worktree add`); MAT bootstrap and `runtime.env` are repo-local layers documented in [`worktree-decision-matrix.md`](worktree-decision-matrix.md), [`configuration.md`](configuration.md), and [`../AGENTS.md`](../AGENTS.md).
+
+## Artifact Taxonomy
+
+This docs set follows one repo-wide artifact taxonomy:
+
+- **Canonical tracked handoffs**: tracked contracts and handoff examples that define accepted workflow interfaces. In this repo, that includes `docs/current-plan.md`, `build-result.md`, and `verify-result.md`.
+- **Tracked distilled evidence**: curated tracked summaries or dated sign-off artifacts kept for review and historical reference.
+- **Local mutable runtime exhaust**: rolling local outputs that help operators during a session but should not churn in commits.
+- **Raw/sensitive captures**: prompt, payload, transcript, or similar captures that may contain high-volume or sensitive runtime detail.
+
+Use [README.md](../README.md) for the short taxonomy summary and [MAINTAINER.md](MAINTAINER.md) for operational handling rules.
+
+## Core Docs
+
+| File | Status | Description |
+| --- | --- | --- |
+| [quick-start.md](quick-start.md) | complete | Fastest path for first use: copy `.env`, start observability, open Cursor, and run slash commands. |
+| [adoption-safe-defaults.md](adoption-safe-defaults.md) | complete | Internal safe-defaults profile: conservative first-run commands, env posture, checklist, escalation. |
+| [getting-started-new-projects.md](getting-started-new-projects.md) | complete | How to bring this workflow into a brand new project with the required `.cursor` layout and environment. |
+| [getting-started-existing-projects.md](getting-started-existing-projects.md) | complete | Safe migration guide for layering the workflow onto an existing repository, including rollback guidance. |
+| [MAINTAINER.md](MAINTAINER.md) | complete | Maintainer readiness checklist covering environment, env vars, rollback, blocked claims, and evidence limits. |
+| [components.md](components.md) | complete | Reference for agents, hooks, skills, utilities, and their inputs, outputs, and file locations. |
+| [configuration.md](configuration.md) | complete | `.env`, `.cursor/hooks.json`, `.cursor/worktrees.json`, `.cursor/mcp.json`, retries, and observability tuning. |
+| [technical-stack.md](technical-stack.md) | complete | High-level overview of the runtime stack: LLM clients, TTS, observability, and isolation model. |
+
+## Architecture Docs
+
+| File | Status | Description |
+| --- | --- | --- |
+| [what-it-can-do-and-how-it-works.md](what-it-can-do-and-how-it-works.md) | complete | Plain-language explanation of capabilities, limits, scope, and internal behavior. |
+| [agent-teams.md](agent-teams.md) | complete | How teams are composed in Cursor using parent orchestration, subagents, and worktrees. |
+| [orchestration-workflow.md](orchestration-workflow.md) | complete | Detailed sequencing, retries, lifecycle transitions, and final synthesis behavior. |
+| [continual-learning-safe-handling.md](continual-learning-safe-handling.md) | draft | Queue-first memory-maintenance design, intentional AGENTS handling, and fallback rules. |
+| [update-mat/index.md](update-mat/index.md) | MVP | Slice 1 updater foundation: footprint manifest, prompt templates, summary schema, rollout. |
+| [long-run-state.md](long-run-state.md) | MVP | Multi-slice mission state template; mission section records `execution_mode`, and each active-slice/queue row uses `execution_mode` plus `execution_rationale`; when a slice originates from an approved onboarding package, the matching `TASK-###` must stay visible in the active slice so `tasks.json` can be synced; pair with [`/mat-long-run`](../.cursor/commands/mat-long-run.md) and [parent orchestrator](../.cursor/agents/parent-orchestrator.md) post-slice mission gate. |
+| [mat-plan-team-spec.md](mat-plan-team-spec.md) | MVP | Plan fixture schema, subagent assignment semantics, trace/honesty boundaries for `/mat-plan-team`. |
+| [todo-orchestration-protocol.md](todo-orchestration-protocol.md) | MVP | Strict MAO Cursor To-do tags, statuses, build→validate gate, hooks notes, fallback. |
+| [todo-orchestration-pilot.md](todo-orchestration-pilot.md) | MVP | Manual end-to-end pilot checklist for the todo protocol. |
+| [todo-orchestration-runtime-evidence.md](todo-orchestration-runtime-evidence.md) | MVP | Committed-artifact audit for TodoWrite/hook proof; local capture via observability DB. |
+| [runtime-messaging.md](runtime-messaging.md) | MVP | Repo-local MAT runtime messaging and durable transport foundation with an adapter-backed store, typed envelopes, outbox/inbox rows, delivery attempts, conservative worker/retry/DLQ handling, and the operator-facing runtime review surface. |
+| [mao-advisory-go-criteria.md](mao-advisory-go-criteria.md) | MVP | Phase 4: maps decision-record advisory go-criteria to procedures and PASS/INCONCLUSIVE outcomes. |
+| [phase4-roadmap-reassessment-checklist.md](phase4-roadmap-reassessment-checklist.md) | MVP | Phase 4: operator checklist for reassessing blocked runtime limitations using evidence procedures. |
+| [todo-write-observability-discovery.md](todo-write-observability-discovery.md) | MVP | Discovery + shipped opt-in **`MaoTodoObservation`** path (`CURSOR_MAO_EMIT_TODO_OBSERVATION_OBSERVABILITY`); live todo column remains runtime-blocked, not merely deferred. |
+| [todo-orchestration-mao-todowrite-application.md](todo-orchestration-mao-todowrite-application.md) | MVP | Focused verification for parent `TodoWrite merge` helpers and optional merge CLI. |
+| [data-flow.md](data-flow.md) | complete | End-to-end flow of prompts, files, hooks, subagents, observability, and outputs. |
+| [events-and-visualization.md](events-and-visualization.md) | complete | The 11 hook events, their payloads/logs, and recommended dashboard widgets. |
+| [observability-retention-policy.md](observability-retention-policy.md) | complete | Advisory retention and sampling policy: SQLite `hook_events`, preview truncation vs stored rows, gitignored growth paths, operator cleanup. |
+
+## Usage Docs
+
+| File | Status | Description |
+| --- | --- | --- |
+| [planning-commands-guide.md](planning-commands-guide.md) | complete | When to use lightweight `/mat-plan` versus heavyweight `/mat-plan-onboarding`, plus projection/handoff guardrails. |
+| [usage-examples-and-cases.md](usage-examples-and-cases.md) | complete | Concrete command-driven examples for planning, building, reviewing, scraping docs, and worktree workflows. |
+| [features-demonstrated.md](features-demonstrated.md) | complete | Inventory of the behaviors this project demonstrates, with pointers to the implementing files. |
+| [best-practices.md](best-practices.md) | complete | Operator and integrator guidance for reliability, safety, cost control, and validation. |
+| [capability-precedence.md](capability-precedence.md) | MVP | Project-first precedence for `.cursor/`, `.mat/`, plugins, and global capabilities; authoritative vs advisory. |
+| [model-routing-policy.md](model-routing-policy.md) | MVP | Conservative MAT routing tiers (`cheap`, `standard`, `strong`), escalation rules, advisory telemetry fields, and deferred adapter boundary. |
+| [routing_advisory.md](routing_advisory.md) | MVP | Advisory-only routing record shape, session rollups, analysis CLI, operational baseline guidance, safe surfacing rules, and operator responses to context pressure. |
+| [context-budget-policy.md](context-budget-policy.md) | MVP | Bounded context per role; artifact-first handoffs; default avoid-list for mega-docs (`README`, `ROADMAP`, `AGENTS`, full `docs/` tree). |
+| [local-app-verification-ladder.md](local-app-verification-ladder.md) | complete | Verification order for local-app pilots: manual/staging baseline, deterministic automation, browser tools, and fallback posture. |
+| [deployment-guide.md](deployment-guide.md) | complete | Deployment and rollout checklist for local/operator environments, observability, and validation. |
+| [troubleshooting.md](troubleshooting.md) | complete | Common problems with Bun, hooks, lifecycle capture, observability, and worktrees. |
+
+## Related Project Docs
+
+| File | Status | Description |
+| --- | --- | --- |
+| [../ROADMAP.md](../ROADMAP.md) | living | Product/engineering roadmap (Vision / Current Focus / Near-Term / Recently Completed / Future Concepts / Icebox / Blocked); maintain during development per [AGENTS.md § Maintaining the roadmap](../AGENTS.md#maintaining-the-roadmap). |
+| [inventory.json](inventory.json) | existing | Asset inventory and migration classification from the Claude-to-Cursor adaptation work. |
+| [migration-backlog.md](migration-backlog.md) | existing | Historical migration backlog from the Stage 0 Cursor translation; use [`../ROADMAP.md`](../ROADMAP.md) for active work and refresh this file only in a dedicated migration audit. |
+| [artifacts-index.md](artifacts-index.md) | existing | Acceptance tracking for artifacts created during the migration stages. |
+| [pilot-report.md](pilot-report.md) | existing | Pilot checklist and evidence template for an end-to-end validation run. |
+| [pilot/pilot-new/README.md](pilot/pilot-new/README.md) | MVP | Adoption pilot for a **new** project (WordPress Switch User scenario): step-by-step, success criteria, risks. |
+| [pilot/pilot-existing/README.md](pilot/pilot-existing/README.md) | MVP | Adoption pilot for an **existing** project (Pancakeswap Prediction Bot): safe bootstrap, `/mat-prime`, `/mat-doctor --full`, bounded slices, onboarding, and paper-trading-first guidance. |
+| [phase1-validation-report.md](phase1-validation-report.md) | existing | Phase 1 sign-off report with final status, evidence, and lifecycle fallback notes. |
+| [hook-payload-verification.md](hook-payload-verification.md) | existing | Hook stdin fields, opt-in capture (`CURSOR_HOOK_CAPTURE_*`, per-session mode), canonical `artifacts/phase1/` samples, contract re-verification when Cursor changes. |
+| [orchestration.md](orchestration.md) | existing | Design-stage orchestration notes that informed the current implementation. |
+| [LIFECYCLE_COMPARISON.md](LIFECYCLE_COMPARISON.md) | existing | Claude Code vs Cursor lifecycle comparison and hook mapping notes. |
+
+## Recommended Reading Order
+
+1. Start with [quick-start.md](quick-start.md) and [adoption-safe-defaults.md](adoption-safe-defaults.md) for a conservative first adoption.
+2. Read [what-it-can-do-and-how-it-works.md](what-it-can-do-and-how-it-works.md).
+3. Use either [getting-started-new-projects.md](getting-started-new-projects.md) or [getting-started-existing-projects.md](getting-started-existing-projects.md).
+4. Then read [configuration.md](configuration.md), [agent-teams.md](agent-teams.md), and [orchestration-workflow.md](orchestration-workflow.md).
+5. Use [planning-commands-guide.md](planning-commands-guide.md), [usage-examples-and-cases.md](usage-examples-and-cases.md), and [best-practices.md](best-practices.md) during day-to-day operation.
+
+## Acceptance Checklist
+
+- [ ] `docs/README.md` links to every doc created in this task.
+- [ ] Each linked file exists and opens from this table of contents.
+- [ ] Status, last-updated, and author are visible in this file.
+- [ ] Root references such as [AGENTS.md](../AGENTS.md) and [README.md](../README.md) resolve correctly.

--- a/.mat/docs/adoption-observability-appendix.md
+++ b/.mat/docs/adoption-observability-appendix.md
@@ -1,0 +1,150 @@
+# Adoption observability appendix
+
+- Purpose: Operator-facing **opt-in** guidance for external product repos that adopt MAT and may enable the Bun/Vue observability stack.
+- Audience: Teams bootstrapping or refreshing MAT in a product repository (not MAT source maintainers only).
+- Status: complete
+- Last updated: 2026-06-23
+- Author: Cursor agent (builder slice — adoption observability appendix)
+
+## Purpose and advisory posture
+
+This appendix is **advisory only**. It describes honest operator practices for optional observability in adopted repos. It is **not** billing telemetry, **not** an enforced retention contract, and **not** a substitute for canonical file handoffs (`docs/current-plan.md`, `build-result.md`, `verify-result.md`, MAO artifacts under `artifacts/mao/`).
+
+MAT observability in MVP has **no shipped automatic TTL, purge job, or hook redaction**. Disk growth and cleanup are **operator-owned** unless you add external tooling. Do not inherit upstream auto-purge or aggressive redaction defaults in product repos.
+
+## When to enable
+
+Observability is **opt-in**. Safe adoption posture:
+
+- **Defer** the observability apps until the basic agent flow works (slash commands, hooks, plan/build/verify handoffs).
+- **Default** to **localhost** and a **single operator** when you first turn the stack on.
+- Enable only when you want dashboard visibility or cross-session debugging — not as proof of workflow authority.
+
+See also [`adoption-safe-defaults.md`](adoption-safe-defaults.md) for conservative first-run habits.
+
+## Enablement
+
+When you choose to run the stack in an **adopted** repo:
+
+1. Ensure `apps/server` and `apps/client` were copied from your MAT source (bootstrap does not always copy full app trees — confirm manifests exist before `bun install`).
+2. Set `OBSERVABILITY_SERVER_URL` in `.env` (see `.env.sample`).
+3. Start the stack:
+
+   ```bash
+   /mat-start
+   ```
+
+   Or from the repo root:
+
+   ```bash
+   bash scripts/start-system.sh
+   ```
+
+4. Open the dashboard URL printed by the start script (ports may differ when defaults are in use).
+
+Hooks POST events via `.cursor/hooks/send_event.py` when the server is reachable. Missing or stopped server behavior is fail-open for workflow continuity — handoff files remain canonical.
+
+## Non-local and shared environments
+
+When observability runs beyond **localhost** (team dashboard, LAN/VPN, CI posting to a central server):
+
+- Set **`OBSERVABILITY_API_TOKEN`** on the server and matching client env (`VITE_OBSERVABILITY_API_TOKEN` for the Vue dashboard WebSocket when required).
+- Store tokens in secrets managers or CI secrets — **never commit** them.
+- **Narrow POST scope** — only trusted runners and operators should POST; review what hook payloads may contain before broad enablement.
+
+Retention and pruning remain **manual** even when auth is enabled. See [`MAINTAINER.md`](MAINTAINER.md#observability-data-handling) for maintainer depth.
+
+## What gets stored
+
+### SQLite `events.sqlite`
+
+The Bun server persists normalized hook events in SQLite:
+
+- **Primary table:** `hook_events` — full JSON in `payload` plus metadata columns.
+- **Database path:** `OBSERVABILITY_DB_PATH` environment variable, default filename **`events.sqlite`** relative to the **server process working directory** (often `apps/server/` when started from that directory, or repo root when using `scripts/start-system.sh` — confirm your launch path before deleting files).
+
+### WebSocket preview vs full SQLite rows
+
+Live dashboard streams use compact wire shapes with **truncated** `payload_preview` for most events (default **800** bytes; larger cap for some MAO advisory event types). **SQLite stores full payloads** unless you prune or delete rows yourself.
+
+**Honesty boundary:** dashboard previews are not complete records of stored rows. Export or query SQLite when you need the full payload.
+
+For maintainer-level detail, see [`observability-retention-policy.md`](observability-retention-policy.md).
+
+## Gitignore expectations
+
+Keep local observability exhaust **out of git**. Typical gitignored surfaces in MAT-adopted repos:
+
+| Path / pattern | Role |
+| --- | --- |
+| `events.sqlite` (and `apps/server/events.sqlite` when created there) | Primary observability SQLite store |
+| `artifacts/phase1/` | Hook capture, verify logs, smoke SQLite copies |
+| `artifacts/mao/` | MAO gate, transition events, todo observations |
+| `artifacts/mat-runtime/` | MAT runtime messaging SQLite |
+| Hook capture trees | Under `CURSOR_HOOK_CAPTURE_DIR` when set |
+
+Bootstrap installs stack-appropriate `.cursorignore` templates; merge product-specific ignores rather than committing runtime databases or raw captures.
+
+## Manual rotate and prune
+
+**No automatic purge** runs in the shipped server. Operators rotate and prune explicitly:
+
+1. **Export before delete** — copy `events.sqlite` or run read-only SQL exports when you need an audit trail.
+2. **Stop the server** before deleting or replacing the SQLite file to avoid partial writes.
+3. **Rotate `events.sqlite`** — rename or move the file, then restart so a fresh database is created at `OBSERVABILITY_DB_PATH` (or the default path).
+4. **Clean phase-1 capture** — periodically review `artifacts/phase1/` (including `raw_payloads*` trees when present) and remove stale captures on a schedule you define.
+
+Use **repo-relative paths** in runbooks (for example `apps/server/events.sqlite`, `artifacts/phase1/`).
+
+## Hook capture directories
+
+Optional hook payload capture is controlled by **`CURSOR_HOOK_CAPTURE_DIR`** and related `CURSOR_HOOK_CAPTURE*` flags (see [`configuration.md`](configuration.md)):
+
+- **Repo-relative paths** resolve from the repository root.
+- **Leading `/` paths** are filesystem-absolute on the machine running hooks.
+
+Capture trees can grow quickly and may contain sensitive `tool_output`. Keep them **gitignored** and prune on an operator-defined schedule. Capture is **off** in safe-defaults posture until you are deliberately collecting evidence.
+
+## RFU-7 deferral (no upstream auto-TTL or hook redaction)
+
+Server-side retention TTL and hook redaction before POST in `send_event.py` are **deferred** (audit **RFU-7**). Adopted repos should document **opt-in** observability and **manual cleanup** — not inherit always-on TTL or aggressive redaction from upstream by default.
+
+Decision record: [`decision-record.md#phase-c-rfu-7--observability-retention-and-hook-redaction-deferred`](decision-record.md#phase-c-rfu-7--observability-retention-and-hook-redaction-deferred).
+
+## Related policy (maintainer depth)
+
+For growth drivers, sampling honesty, recommended operator practices, and non-goals in the MAT source repo, see [`observability-retention-policy.md`](observability-retention-policy.md).
+
+## Product README checklist
+
+Copy or adapt this block into your product repo README when observability is optional but documented:
+
+```markdown
+## MAT observability (optional)
+
+- **Opt-in:** defer until basic `/mat-plan-team` or `/mat-sprint` flow works.
+- **Start:** `bash scripts/start-system.sh` or `/mat-start` when `apps/server` and `apps/client` are installed.
+- **Storage:** local `events.sqlite` (path depends on launch cwd; see `.mat/docs/adoption-observability-appendix.md`).
+- **Gitignore:** `events.sqlite`, `artifacts/phase1/`, `artifacts/mao/`, `artifacts/mat-runtime/`, hook capture dirs.
+- **Rotation:** manual only — stop server, backup/export, delete or rename DB, restart. No shipped auto-purge.
+- **Shared use:** set `OBSERVABILITY_API_TOKEN`; never commit tokens.
+- **Authority:** file handoffs (`build-result.md`, `verify-result.md`) — not dashboard rows alone.
+- **Depth:** `.mat/docs/adoption-observability-appendix.md` and `.mat/docs/observability-retention-policy.md` when packaged.
+```
+
+## Bootstrap and update packaging
+
+On bootstrap or `update-mat.py` apply, this appendix is copied to **`.mat/docs/adoption-observability-appendix.md`** via [`scripts/adoption/adoption-layout-v1.json`](../scripts/adoption/adoption-layout-v1.json). Product repos with minimal root `docs/` should link from README or operator runbooks to the `.mat/docs/` copy after refresh.
+
+## Related evidence
+
+- [Adoption observability pilot report (2026-06-23)](../artifacts/report/adoption-observability-pilot-2026-06-23.md) — disposable bootstrap + `update-mat.py` dry-run evidence for appendix packaging and `AGENTS.md` preservation.
+
+## Related docs
+
+- [`getting-started-new-projects.md`](getting-started-new-projects.md)
+- [`getting-started-existing-projects.md`](getting-started-existing-projects.md)
+- [`adoption-safe-defaults.md`](adoption-safe-defaults.md)
+- [`configuration.md`](configuration.md)
+- [`events-and-visualization.md`](events-and-visualization.md)
+- [`update-mat/index.md`](update-mat/index.md)

--- a/.mat/docs/components.md
+++ b/.mat/docs/components.md
@@ -1,0 +1,207 @@
+# Components Reference
+
+- Purpose: Reference the major components in the Cursor-native multi-agent workflow and show how they fit together.
+- Audience: Operators, maintainers, and contributors who need a file-level map of the system.
+- Prerequisites: Familiarity with Cursor agents, hooks, and slash commands.
+- Status: complete
+- Last updated: 2026-04-20
+- Author: Cursor agent (GPT-5.4)
+- Repo posture: internal/reference-oriented for the maintainer team; not a public packaging target by default.
+
+## Related Files
+
+- [Agent instructions](../AGENTS.md)
+- [Hook manifest](../.cursor/hooks.json)
+- [Configuration](configuration.md)
+- [Agent teams](agent-teams.md)
+- [Orchestration workflow](orchestration-workflow.md)
+- [Inventory](inventory.json)
+- [Artifacts index](artifacts-index.md)
+- [Capability precedence](capability-precedence.md) — project-local vs `.mat/`, plugin, and global capabilities
+- [Model routing policy](model-routing-policy.md) — conservative `cheap` / `standard` / `strong` MAT routing guidance
+- [Routing advisory surface](routing_advisory.md) — advisory record shape and safe surfacing rules
+- [Context budget policy](context-budget-policy.md) — bounded context and artifact-first loading
+
+## Component Map
+
+| Component | Purpose | Key paths |
+|-----------|---------|-----------|
+| Observability client (Vue) | Live hook timeline, pulse chart, transcript, MAO visibility, runtime review, Help modal | `apps/client/src/` (see `App.vue`, `EventCard.vue`, `HelpModal.vue`, `components/RuntimeReviewPanel.vue`) |
+| Planning commands | Lightweight solo planning and heavyweight onboarding package authoring | `.cursor/commands/mat-plan.md`, `.cursor/commands/mat-plan-onboarding.md`, `docs/planning-commands-guide.md` |
+| Parent Orchestrator | Decompose, delegate, retry, synthesize | `.cursor/agents/parent-orchestrator.md`, `.cursor/commands/mat-plan-team.md`, `.cursor/commands/mat-long-run.md`, `.cursor/commands/mat-subagents-spawn.md` |
+| Builder | Implement and self-validate | `.cursor/agents/builder.md`, `.cursor/commands/mat-build.md` |
+| Verifier | Read-only acceptance checking | `.cursor/agents/verifier.md`, `.cursor/commands/mat-review.md` |
+| Test Writer | Focused regression test authoring | `.cursor/agents/test-writer.md` |
+| Style Reviewer | Docs/style consistency and claim hygiene | `.cursor/agents/style-reviewer.md` |
+| Meta Agent | Generate new agent definitions | `.cursor/agents/meta-agent.md` |
+| Scout | Read-only investigation and issue detection | `.cursor/agents/scout-report-suggest.md` |
+| Docs Scraper | Fetch docs into markdown | `.cursor/agents/docs-scraper.md` |
+| Worktree Creator | Automate isolated worktree setup | `.cursor/agents/create-worktree-subagent.md`, `.cursor/commands/mat-wt-create.md` |
+| Demo Agent | Demonstrate end-to-end behavior | `.cursor/agents/demo-agent.md` |
+| Hooks | Lifecycle automation and observability | `.cursor/hooks.json`, `.cursor/hooks/` |
+| Cursor rules | Composer constraints (e.g. MAO todos) | `.cursor/rules/orchestrator-todos.mdc` |
+| MAT runtime messaging | Repo-local typed event, subscription-policy, outbox/inbox, delivery-attempt, worker/retry/DLQ control plane plus the operator-facing runtime review panel and review API | `.cursor/hooks/utils/runtime_messaging.py`, `scripts/mat-runtime.py`, `apps/server/src/runtime-review.ts`, `apps/client/src/composables/useRuntimeReview.ts`, `apps/client/src/components/RuntimeReviewPanel.vue`, `docs/runtime-messaging.md` |
+| Capability policy | Project-first routing doc (not a runtime loader) | `docs/capability-precedence.md` |
+| Routing policy | Conservative model tiers and advisory budget notes | `docs/model-routing-policy.md` |
+| Routing advisory surface | Advisory-only record shape, session rollups, and safe surfacing | `docs/routing_advisory.md` |
+| Context budget policy | Bounded context per role; avoid habitual mega-doc loads | `docs/context-budget-policy.md` |
+| Skills | Reusable operator guidance | `.cursor/skills/` |
+| Utilities | LLM, HITL, TTS, routing advisories, rollups, summaries, validators | `.cursor/hooks/utils/`, `.cursor/hooks/validators/` |
+
+## Planning Commands
+
+- Purpose: Capture planning truth before any execution handoff.
+- Responsibilities: Keep `/mat-plan` lightweight and single-file; keep `/mat-plan-onboarding` heavyweight, traceable, and approval-gated.
+- Inputs: User task, relevant repo context, existing `specs/` artifacts when present.
+- Outputs: `specs/<slug>.md` for `/mat-plan`, or `specs/<slug>/prd.md`, `specs/<slug>/spec.md`, `specs/<slug>/tasks.json`, and `specs/<slug>/plan-summary.md` for `/mat-plan-onboarding`.
+- Relevant paths: `../.cursor/commands/mat-plan.md`, `../.cursor/commands/mat-plan-onboarding.md`, `../docs/planning-commands-guide.md`.
+- Example invocations:
+
+```text
+/mat-plan Improve the onboarding checklist copy
+/mat-plan-onboarding Design a new planning workflow with traceable tasks
+```
+
+Planning truth stays in `specs/`. `docs/current-plan.md` remains execution truth for downstream builder/verifier flows.
+
+## Agents
+
+### Parent Orchestrator
+
+- Purpose: Replaces Claude's team lead pattern with file-based coordination.
+- Responsibilities: Write `docs/current-plan.md`, spawn builder and verifier, evaluate retries, write final synthesis; when execution comes from an approved onboarding package, keep the matching `tasks.json` status in sync with the active slice; for long-run missions, maintain `docs/long-run-state.md` and run the post-slice mission gate after each verifier PASS.
+- Inputs: User task, `docs/current-plan.md`, `build-result.md`, `verify-result.md`.
+- Outputs: `docs/current-plan.md`, `docs/session-summary.md`, final user summary; optional `docs/long-run-state.md` for multi-slice missions; optional `specs/<slug>/tasks.json` status updates when onboarding packages are active.
+- Config options: Retry limits are encoded in the prompt and influenced by `loop_limit` in `../.cursor/hooks.json`.
+- Relevant paths: `../.cursor/agents/parent-orchestrator.md`, `../.cursor/commands/mat-plan-team.md`, `../.cursor/commands/mat-long-run.md`, `../.cursor/commands/mat-subagents-spawn.md`, `../docs/mat-plan-team-spec.md`, `../.cursor/orchestration-capabilities.json`, `../artifacts/agent-traces/README.md`.
+- Example invocation:
+
+```text
+/mat-plan-team Implement a small feature and verify it
+```
+
+- Multi-slice missions:
+
+```text
+/mat-long-run Execute roadmap slices 1–3 with explicit queue in docs/long-run-state.md
+```
+
+- Related lightweight command variants: `../.cursor/commands/mat-sprint.md`, `../.cursor/commands/mat-lite.md`, `../.cursor/commands/mat-doctor.md`.
+
+### Builder
+
+- Purpose: Performs implementation work.
+- Responsibilities: Make changes, run validation, write `build-result.md`.
+- Inputs: `docs/current-plan.md`.
+- Outputs: `build-result.md`.
+- Config options: Uses project lint/type-check commands; receives feedback through `postToolUse` and `afterFileEdit`.
+- Relevant paths: `../.cursor/agents/builder.md`, `../.cursor/commands/mat-build.md`.
+- Example invocation:
+
+```text
+/mat-build Add a helper function and document the result
+```
+
+### Verifier
+
+- Purpose: Validate builder output without changing implementation files.
+- Responsibilities: Inspect handoff files and changed files, then write `verify-result.md`.
+- Inputs: `docs/current-plan.md`, `build-result.md`.
+- Outputs: `verify-result.md`.
+- Config options: Read-only workflow; evidence requirements are defined in the verifier prompt.
+- Relevant paths: `../.cursor/agents/verifier.md`, `../.cursor/commands/mat-review.md`.
+- Example invocation:
+
+```text
+/mat-review
+```
+
+### Test Writer
+
+- Purpose: Add focused test coverage without expanding feature scope.
+- Responsibilities: Identify coverage gaps, add deterministic tests, run targeted test commands.
+- Inputs: Existing module behavior and test suite context.
+- Outputs: Updated test files and command evidence.
+- Relevant paths: `../.cursor/agents/test-writer.md`.
+
+### Style Reviewer
+
+- Purpose: Keep docs and workflow guidance concise, aligned, and truthful.
+- Responsibilities: Normalize inventories and remove unsupported runtime claims.
+- Inputs: `README.md`, `AGENTS.md`, `docs/`, and `.cursor/commands/`.
+- Outputs: Focused copy/style updates with consistency checks.
+- Relevant paths: `../.cursor/agents/style-reviewer.md`.
+
+### Meta Agent
+
+- Purpose: Agent factory for new `.cursor/agents/*.md` definitions.
+- Responsibilities: Infer name, read-only mode, workflow, output format, and notes for a new agent file.
+- Inputs: User description of a desired agent.
+- Outputs: A new agent definition file under `.cursor/agents/`.
+- Config options: Conventions come from existing agent files and `AGENTS.md`.
+- Relevant paths: `../.cursor/agents/meta-agent.md`.
+- Example invocation:
+
+```text
+Use the meta-agent to create a deployment-checker subagent
+```
+
+### Scout, Docs Scraper, Worktree Creator, Demo Agent
+
+| Component | Inputs | Outputs | Example |
+|-----------|--------|---------|---------|
+| Scout | Problem statement, file references | SCOUT REPORT text | "Investigate why validation is skipped" |
+| Docs Scraper | One or more URLs | Markdown files under `ai_docs/` | "Fetch Bun docs to local markdown" |
+| Worktree Creator | Branch / worktree label | New git worktree, bootstrap, `runtime.env` hints | `/mat-wt-create feature-x` |
+| Demo Agent | Simple task prompt | `demo-output/hello.md` and demo report | "Run the demo agent" |
+
+## Hooks
+
+The project wires 11 events in [`../.cursor/hooks.json`](../.cursor/hooks.json):
+
+| Event | Primary job | Main script(s) |
+|-------|-------------|----------------|
+| `beforeSubmitPrompt` | Prompt logging and validation | `before_submit_prompt.py` |
+| `sessionStart` | Session initialization | `session_start.py` |
+| `sessionEnd` | Session statistics and end logging | `session_end.py` |
+| `preToolUse` | Pre-execution checks | `pre_tool_use.py` |
+| `postToolUse` | Event emission and validation | `send_event.py`, `post_tool_validate.py` (also refreshes `mao_gate.py` → `artifacts/mao/gate.json` when `build-result.md` is written) |
+| `postToolUseFailure` | Error logging | `post_tool_use_failure.py` |
+| `afterFileEdit` | Post-edit formatting | `after_file_edit.py` |
+| `subagentStart` | Subagent lifecycle logging | `subagent_start.py` |
+| `subagentStop` | Subagent lifecycle event emission | `send_event.py` |
+| `stop` | Observability emit + wired `stop_validator.py` (Phase 1 permissive: advisory stderr warnings for incomplete orchestration handoffs when applicable; repo-default `failClosed` false) | `send_event.py`, `stop_validator.py` |
+| `preCompact` | Compaction logging and backups | `pre_compact.py` |
+
+## Skills
+
+Routing posture (commands vs skills, hybrid worktree cluster): [P1 Audit — Skills vs Commands Routing](decision-record.md#p1-audit--skills-vs-commands-routing).
+
+Cloud / Agents Window posture (Cursor 3 language, no MAT auto-provision): [P1 Audit — Cloud Agents and Agents Window](decision-record.md#p1-audit--cloud-agents-agents-window); setup detail in [`worktree-decision-matrix.md`](worktree-decision-matrix.md).
+
+| Skill | Purpose | Path | Example use |
+|-------|---------|------|-------------|
+| `the-library` | Private-first skill distribution | `.cursor/skills/the-library/SKILL.md` | Install or distribute internal skills |
+| `meta-skill` | Guide to creating new skills | `.cursor/skills/meta-skill/SKILL.md` | Create a repo-specific skill |
+| `worktree-manager` | Full worktree lifecycle guidance | `.cursor/skills/worktree-manager/SKILL.md` | Decide when to create/list/remove worktrees |
+| `create-worktree` | Lightweight worktree creation | `.cursor/skills/create-worktree/SKILL.md` | Quick branch-isolated setup |
+
+## Utilities And Validators
+
+| Utility | Purpose | Path | Notes |
+|---------|---------|------|-------|
+| Constants | Shared project/session paths | `.cursor/hooks/utils/constants.py` | Centralizes log directory handling |
+| Summarizer | One-line LLM summaries | `.cursor/hooks/utils/summarizer.py` | Uses Anthropic utility client |
+| HITL | Human approvals and choices | `.cursor/hooks/utils/hitl.py` | Sends WebSocket-backed approval requests |
+| Anthropic client | Fast completion helper | `.cursor/hooks/utils/llm/anth.py` | Used for summaries and naming |
+| OpenAI client | Alternative completion helper | `.cursor/hooks/utils/llm/oai.py` | Used for summaries |
+| TTS helpers | Audio notifications | `.cursor/hooks/utils/tts/` | ElevenLabs, OpenAI, or offline pyttsx3 |
+| `validate_file_contains.py` | Optional content check helper | `.cursor/hooks/validators/validate_file_contains.py` | Not wired on shipped `stop`; may block only if you add it to a custom `hooks.json` |
+| `validate_new_file.py` | Optional file-creation check helper | `.cursor/hooks/validators/validate_new_file.py` | Not wired on shipped `stop`; may block only if you add it to a custom `hooks.json` |
+
+## Acceptance Checklist
+
+- [ ] Every major component in the workflow is represented in this file.
+- [ ] Each component points to at least one concrete file path in the repo.
+- [ ] Example invocations align with available slash commands or agent prompts.
+- [ ] The component list matches `AGENTS.md` and `../.cursor/hooks.json`.

--- a/.mat/docs/getting-started-existing-projects.md
+++ b/.mat/docs/getting-started-existing-projects.md
@@ -1,0 +1,158 @@
+# Getting Started In Existing Projects
+
+- Purpose: Explain how to add the multi-agent workflow to an already active repository with minimal disruption.
+- Audience: Maintainers integrating this workflow into a codebase with existing conventions, branches, and CI.
+- Prerequisites: Existing git repo, Cursor, ability to test changes safely, and familiarity with your current project build/test commands.
+- Status: complete
+- Last updated: 2026-06-24
+- Author: Cursor agent (GPT-5.4)
+
+## Related Files
+
+- [Adoption safe defaults](adoption-safe-defaults.md) — conservative first-run profile (internal)
+- [Root README](../README.md)
+- [Agent instructions](../AGENTS.md)
+- [Hook manifest](../.cursor/hooks.json)
+- [Configuration](configuration.md)
+- [Agent teams](agent-teams.md)
+- [Workflows](orchestration-workflow.md)
+- [Migration backlog](migration-backlog.md) - historical Stage 0 reference only; use `ROADMAP.md` for active work
+- [Pilot report](pilot-report.md)
+- [Artifacts index](artifacts-index.md)
+- [Capability precedence](capability-precedence.md) — how project `.cursor/` relates to `.mat/`, plugins, and global defaults
+
+## Sidecar mental model (MAT v1)
+
+Bootstrap keeps **product-owned** README/CHANGELOG/AGENTS at the repo root when those files already exist. Full MAT reference material is written to **`.mat/`** (documentation under `.mat/docs/`, contract tests under `.mat/tests/`, and `.mat/AGENTS.mat.md`). The adoption helper adds a short pointer note to each detected product-owned `AGENTS.md` by default, computes the link relative to the file being edited, and leaves the inline delimited MAT section for an explicit `--inline-fallback` run. Root `docs/` only receives minimal workflow handoff files (`docs/current-plan.md`, `docs/long-run-state.md`) when missing.
+
+## Migration Checklist
+
+- [ ] Review the current repo layout and existing automation.
+- [ ] Decide whether hooks should be enabled immediately or staged behind a feature branch.
+- [ ] Copy `.cursor/agents`, `.cursor/commands`, `.cursor/hooks`, `.cursor/skills`, `hooks.json`, `mcp.json`, and `worktrees.json` (or run the bootstrap script, which installs them).
+- [ ] Keep or merge your existing `AGENTS.md`; treat `.mat/AGENTS.mat.md` as the full MAT encyclopedia without replacing your product narrative file blindly.
+- [ ] Merge `.env.sample` requirements into your existing secret management.
+- [ ] Map the builder/verifier validation commands to your repo's real test and lint commands.
+- [ ] Run a pilot workflow before enabling the setup for daily work.
+
+## Safe Integration Steps
+
+1. Create a dedicated integration branch.
+2. Run the non-interactive adoption bootstrap from this workflow repo:
+
+```bash
+export MULTI_AGENT_WORKFLOW_ROOT=/absolute/path/to/multi-agent-workflow
+bash "$MULTI_AGENT_WORKFLOW_ROOT/scripts/adoption/bootstrap-workflow-into-repo.sh" --mode existing-project --non-interactive "$(pwd)"
+```
+
+3. If your repo already has an older `docs/long-run-state.md`, run the upgrade helper in the adopted repo:
+
+```bash
+python3 scripts/adoption/migrate-long-run-state.py docs/long-run-state.md
+```
+
+4. If you need to refresh nested or monorepo `AGENTS.md` files after a repo layout change, run `python3 scripts/adoption/manage-agents-sidecars.py --repo-root .` from the adopted repo root.
+5. Keep `CURSOR_VALIDATE_PROMPTS=false` and `CURSOR_DESKTOP_NOTIFICATIONS=false` until the basic hook flow is stable.
+6. Verify hooks and slash commands in Cursor before enabling more aggressive validators.
+7. Run a small orchestrated task rather than a large production change as the first trial.
+
+The bootstrap preserves existing `docs/current-plan.md` and `docs/long-run-state.md` files when they already exist. Packaged MAT documentation is installed under **`.mat/docs/`** (not merged into your product `docs/` tree). Workflow contract tests ship under **`.mat/tests/`**; run them with `python3 -m unittest discover -s .mat/tests -p 'test_*.py' -v` when you want MAT regression coverage in the adopted repo. The sidecar helper writes a temporary backup copy of each edited `AGENTS.md` before changing it, so recovered content stays available without polluting the repo.
+
+The migration helper only auto-fixes the specific stale case where the mission section is missing `- **execution_mode:** \`long-run\`` or `short-run`; otherwise it exits non-zero with a remediation message so you can update the file deliberately.
+
+## First adoption vs refresh
+
+**First-time existing-project adoption requires bootstrap** (`bootstrap-workflow-into-repo.sh` above). A pristine `update-mat.py` dry-run on a repo without `.mat/AGENTS.mat.md` is expected to fail — run bootstrap first, then use `update-mat.py` for incremental refresh after the sidecar exists. See the [rank-math-api-manager adoption pilot](../artifacts/report/adoption-rank-math-api-manager-pilot-2026-06-24.md) (2026-06-24) for disposable evidence of that order.
+
+## Refreshing MAT later
+
+**Two honest paths:**
+
+1. **`update-mat.py` (preferred for incremental drift)** — compares your adopted tree against a checked-out MAT **source** repo, shows a dry-run plan first, and can stage changes in an isolated worktree. It respects footprint rules for product-owned files; review `.cursorignore`, root `AGENTS.md`, and any product docs the diff touches before approving `--apply`. See [`docs/update-mat/index.md`](update-mat/index.md), [`docs/update-mat/architecture-and-rollout.md`](update-mat/architecture-and-rollout.md), and the slice 3 operator checklist in [`validation-report.md`](../validation-report.md).
+
+2. **Re-run `bootstrap-workflow-into-repo.sh`** — overwrites **MAT-managed** paths from the layout manifest (`.cursor/` workflow bundle, `scripts/` copies, `.mat/docs/`, `.mat/tests/`, sidecar README, vendor README, `.env.sample`, etc.) while **preserving** existing root `README.md`, `CHANGELOG.md`, and `AGENTS.md` in `--mode existing-project`, and preserving `docs/current-plan.md` / `docs/long-run-state.md` when already present. It does **not** bulk-merge MAT’s full root `docs/` tree into your product docs. Bootstrap ends with **legacy cleanup**: `apply_mat_legacy_cleanup.py` reads `scripts/adoption/mat-legacy-migrations-v1.json`, retires known obsolete slash-command stubs when safe (fingerprint match or warn-only policy), and never removes paths listed in `scripts/adoption/mat-footprint-v1.json` `preserve_paths`. After either path, run `bash scripts/phase1-verify.sh` from the adopted repo root (it runs the **adopted** profile when `.mat/README.md` exists: packaged `.mat/tests`, explicit skips for unpackaged surfaces).
+
+### Updater checklist (dry-run first)
+
+Follow [`validation-report.md`](../validation-report.md) slice 3 — summary:
+
+1. **Dry-run (default):** `python3 scripts/adoption/update-mat.py --source /absolute/path/to/multi-agent-workflow --ref main`
+2. **Review:** `plan-file=`, `patch-file=`, `audit-file=`, compatibility snapshot, and `legacy_cleanup_preview` in the plan JSON.
+3. **Resolve conflicts** and nested `AGENTS.md` ambiguity before apply (`manage-agents-sidecars.py` when needed).
+4. **Apply staging only with explicit flags:** `--apply --approved --plan-file <plan.json>`.
+5. **Inspect** `staging-worktree=` output; confirm **no new commit** on the target root.
+6. **Manual commit/PR** — the updater stops before those steps ([`docs/adoption-safe-defaults.md`](adoption-safe-defaults.md)).
+
+```bash
+python3 scripts/adoption/update-mat.py --source /absolute/path/to/multi-agent-workflow --ref main
+```
+
+That command defaults to **dry-run** and prints a patch preview first. Review the summary, the compatibility snapshot from `scripts/adoption/mat-footprint-v1.json`, and the supporting bundle in [`docs/update-mat/`](update-mat/index.md). Confirm that the only project-owned edits are the `AGENTS.md` pointer or inline-fallback blocks handled by the sidecar helper, and only then rerun with `--apply --approved --plan-file <saved-plan.json>` to stage the update in an isolated worktree or branch-like path.
+
+If the preview shows conflicts or nested `AGENTS.md` ambiguity, stop and resolve it manually before any commit or PR step. The updater intentionally **stops before commit or PR creation** so the operator can make the final call.
+
+## Worktree Hints
+
+Worktrees are the safest way to test parallel-agent behavior in an existing codebase. Create them **explicitly** (`git worktree`, Cursor `/worktree`, etc.); Cursor 3 does not silently add a git worktree per parallel agent. After each tree exists, run MAT bootstrap so `.cursor/worktree/runtime.env` records collision-aware `OBSERVABILITY_PORT` / `OBSERVABILITY_CLIENT_PORT` hints (see `.cursor/hooks/bootstrap_worktree.sh`).
+
+```text
+/mat-wt-create feature-multi-agent-docs
+/mat-wt-list
+```
+
+Why this helps:
+
+- Builder and verifier can run against isolated branches.
+- Bootstrap can copy `.env` from the project root and keep observability hints in `runtime.env` separate from the main workspace.
+- You can remove the experiment cleanly if needed.
+
+## Suggested Roll-In Order
+
+1. `AGENTS.md`
+2. `.cursor/commands/`
+3. `.cursor/agents/`
+4. `.cursor/hooks.json` and `.cursor/hooks/`
+5. `.cursor/worktrees.json`
+6. Optional observability apps and TTS integrations — defer until the basic agent flow works; when you enable them, follow [`adoption-observability-appendix.md`](adoption-observability-appendix.md) for opt-in posture, `events.sqlite` gitignore, manual rotation, and shared-environment token guidance. For reproducible bootstrap + `update-mat.py` dry-run evidence, see the [adoption observability pilot report](../artifacts/report/adoption-observability-pilot-2026-06-23.md) (2026-06-23).
+
+## Common Pitfalls
+
+- Replacing existing repo instructions instead of merging them into `AGENTS.md`.
+- Assuming Claude-specific task-board or messaging features exist in Cursor.
+- Turning on stop-loop enforcement before builders and verifiers are tuned to your repo's real acceptance criteria.
+- Forgetting that worktrees may need extra setup for databases, generated files, or package installs.
+- Expecting PermissionRequest-like hooks; Cursor handles permission gating differently inside the runtime.
+
+## Rollback Steps
+
+If the integration causes friction, revert in this order:
+
+1. Disable or remove `.cursor/hooks.json`.
+2. Remove `.cursor/hooks/` if hook execution is the source of failures.
+3. Keep `AGENTS.md` if it is still useful as human-readable guidance.
+4. Remove or archive `.cursor/commands/` if you want to fall back to manual prompting.
+5. Delete experimental worktrees with `/mat-wt-remove <branch>`.
+
+## Practical Example
+
+Trial the workflow on a documentation-only change first:
+
+```text
+/mat-plan-team Add a short integration guide for our API package
+```
+
+Verification targets:
+
+- Hook logs appear in `logs/<session_id>/`.
+- The parent produces `docs/current-plan.md`.
+- The verifier report is readable and evidence-based.
+- No unrelated project files are modified.
+
+## Acceptance Checklist
+
+- [ ] The workflow was introduced on an isolated branch or worktree.
+- [ ] Existing project instructions in `AGENTS.md` were preserved or deliberately merged; `.mat/AGENTS.mat.md` holds the full MAT reference.
+- [ ] A small pilot task completed with `build-result.md` and `verify-result.md`.
+- [ ] Rollback is documented and tested at least once.
+- [ ] Maintainers understand which parts are optional: observability apps, TTS, HITL, and external MCP integrations.
+- [ ] If observability is enabled, operators read [`adoption-observability-appendix.md`](adoption-observability-appendix.md) (packaged to `.mat/docs/` on bootstrap/update) for manual rotation, gitignore surfaces, and RFU-7 deferral honesty.

--- a/.mat/docs/getting-started-new-projects.md
+++ b/.mat/docs/getting-started-new-projects.md
@@ -1,0 +1,162 @@
+# Getting Started In New Projects
+
+- Purpose: Show how to install this Cursor-native multi-agent workflow into a brand new repository.
+- Audience: Developers bootstrapping a fresh project.
+- Prerequisites: A new project folder, Git, Cursor, Python 3, and any runtime dependencies used by your target codebase.
+- Status: complete
+- Last updated: 2026-04-16
+- Author: Cursor agent (GPT-5.4)
+
+## Missing Prerequisites
+
+- In **this MAT reference repository**, `apps/server/package.json` and `apps/client/package.json` define the Bun/Vue observability stack. In a **brand-new empty repo** you adopt into, copy those app trees (or equivalent manifests) from your runnable source of truth before expecting `bun install` in those paths to work.
+
+## Related Files
+
+- [Adoption safe defaults](adoption-safe-defaults.md) — conservative first-run profile (internal)
+- [Root README](../README.md)
+- [Agent instructions](../AGENTS.md)
+- [Hook manifest](../.cursor/hooks.json)
+- [Configuration](configuration.md)
+- [Components](components.md) (MAT reference repo); in an adopted repo, the packaged copy is under `.mat/docs/components.md`.
+- [Inventory](inventory.json)
+- [Migration backlog](migration-backlog.md) - historical Stage 0 reference only; use `ROADMAP.md` for active work
+- [Pilot report](pilot-report.md)
+- [Artifacts index](artifacts-index.md)
+- [Capability precedence](capability-precedence.md) — project-first routing when mixing global, plugin, and `.mat/` assets
+
+## Prerequisites
+
+- A git repository initialized with `main` or your preferred base branch.
+- Cursor configured to load project `.cursor/commands`, `.cursor/agents`, `.cursor/skills`, and project hooks.
+- API keys as needed:
+  - `ANTHROPIC_API_KEY`
+  - `OPENAI_API_KEY`
+  - `ELEVENLABS_API_KEY` (optional)
+- Optional local tools for validators and formatting:
+  - `ruff`
+  - `ty`, `pyright`, or your preferred type checker
+  - `prettier` for JS/TS formatting
+
+## Recommended Project Layout (MAT v1 sidecar)
+
+Product identity stays at the repository root. MAT-packaged manuals and workflow contract tests live under **`.mat/`** so they do not compete with your product `docs/` tree. New-project bootstrap writes a product-first `AGENTS.md` that points at `.mat/AGENTS.mat.md`; use the helper's `--inline-fallback` flag only when you explicitly want the delimited inline MAT section in a particular file.
+
+```text
+your-project/
+  .cursor/
+    agents/
+    commands/
+    hooks/
+    skills/
+    hooks.json
+    mcp.json
+    worktrees.json
+  .mat/
+    README.md
+    docs/           # packaged MAT workflow documentation
+    tests/          # workflow unittest modules (contract tests)
+    AGENTS.mat.md   # full MAT operator reference (from source AGENTS.md)
+  AGENTS.md         # product-first; points at .mat/ for deep reference
+  .env.sample
+  docs/             # minimal workflow handoffs only: current-plan, long-run-state
+```
+
+## Installation Steps
+
+1. Initialize the new repository with your normal starter files (`README.md`, optional `LICENSE`, language/runtime files).
+2. Run the non-interactive bootstrap from this workflow repo:
+
+```bash
+export MULTI_AGENT_WORKFLOW_ROOT=/absolute/path/to/multi-agent-workflow
+bash "$MULTI_AGENT_WORKFLOW_ROOT/scripts/adoption/bootstrap-workflow-into-repo.sh" --mode new-project --non-interactive "$(pwd)"
+```
+
+3. Review the copied workflow assets and adapt `AGENTS.md` plus `.env.sample` for your project.
+4. If the repo later grows nested packages or services with their own `AGENTS.md` files, rerun `python3 scripts/adoption/manage-agents-sidecars.py --repo-root .` to refresh the relative sidecar pointers without overwriting product-owned content.
+5. Decide whether to include the observability apps immediately or defer them until after the basic agent flow works. When you enable them later, use [`adoption-observability-appendix.md`](adoption-observability-appendix.md) for opt-in enablement, `events.sqlite` storage, manual rotate/prune, gitignore expectations, and shared `OBSERVABILITY_API_TOKEN` guidance (packaged to `.mat/docs/` on bootstrap/update). For reproducible bootstrap + dry-run evidence, see the [adoption observability pilot report](../artifacts/report/adoption-observability-pilot-2026-06-23.md) (2026-06-23).
+
+The bootstrap creates a curated workflow surface: `.cursor/commands/`, `.cursor/agents/`, hook/config files, root `docs/current-plan.md` and `docs/long-run-state.md` (minimal MAO/mat-long-run handoffs), **`.mat/docs/`** for packaged MAT documentation, and **`.mat/tests/`** for workflow contract tests. Run those tests with:
+
+`python3 -m unittest discover -s .mat/tests -p 'test_*.py' -v`
+
+If you later want to refresh the MAT-owned workflow files from upstream, use `python3 scripts/adoption/update-mat.py --source <upstream-repo-or-url> --ref <ref>` and inspect the **dry-run** diff first (default mode). Existing project-owned `AGENTS.md` content still stays under the sidecar helper’s control, and the updater's contract bundle lives in [`docs/update-mat/`](update-mat/index.md). For the full operator checklist (dry-run → review → apply staging → manual commit), see [`validation-report.md`](../validation-report.md) slice 3 and [`docs/adoption-safe-defaults.md`](adoption-safe-defaults.md).
+
+## Environment Variables
+
+Start from `.env.sample` and fill at least the values you intend to use:
+
+```bash
+cp .env.sample .env
+```
+
+Important variables:
+
+| Variable | Required | Why it matters |
+|----------|----------|----------------|
+| `OBSERVABILITY_SERVER_URL` | Recommended | Tells hooks where to POST events. |
+| `ANTHROPIC_API_KEY` | Optional | Enables Anthropic-backed summaries and agent naming. |
+| `OPENAI_API_KEY` | Optional | Enables OpenAI-backed summaries and TTS. |
+| `ELEVENLABS_API_KEY` | Optional | Enables ElevenLabs TTS. |
+| `CURSOR_DESKTOP_NOTIFICATIONS` | Optional | Enables macOS stop notifications. |
+| `CURSOR_STORE_PROMPTS` | Optional | Persists prompts to `.cursor/data/sessions/`. |
+| `CURSOR_NAME_AGENT` | Optional | Generates session agent names. |
+| `CURSOR_VALIDATE_PROMPTS` | Optional | Turns on prompt blocking rules. |
+| `CURSOR_HOOKS_LOG_DIR` | Optional | Overrides the default `logs/` directory. |
+
+## Starting The Stack
+
+If you copied the observability applications and they are runnable in your project:
+
+```bash
+cd apps/server && bun install && bun run dev
+cd apps/client && bun install && bun run dev
+```
+
+Then open the project in Cursor and run:
+
+```text
+/mat-prime
+/mat-plan-team Build a tiny smoke-test feature for this new project
+```
+
+## Verifying The Setup
+
+Check these in order:
+
+1. `.cursor/hooks.json` loads without Cursor errors.
+2. Slash commands appear from `.cursor/commands/`.
+3. `docs/current-plan.md` and `docs/long-run-state.md` were created by the bootstrap.
+4. `logs/<session_id>/user_prompts.json` appears after the first prompt.
+5. `build-result.md` and `verify-result.md` appear after `/mat-plan-team`.
+6. If the observability stack is running, events appear from `.cursor/hooks/send_event.py`.
+
+## Practical Example
+
+For a brand new Python project:
+
+```text
+/mat-plan-team Create a hello-world module with tests and verify it
+```
+
+Expected outcome:
+
+- The parent writes `docs/current-plan.md`.
+- The builder implements the module and writes `build-result.md`.
+- The verifier writes `verify-result.md`.
+- Hook logs are created in `logs/<session_id>/`.
+
+## Common Setup Mistakes
+
+- Copying `commands/` and `agents/` without `hooks.json`.
+- Forgetting to add `.env`, then expecting summaries or TTS to work.
+- Enabling prompt validation before defining blocked patterns in `before_submit_prompt.py`.
+- Assuming worktree bootstrap or observability apps are complete without checking their local runtime dependencies.
+
+## Acceptance Checklist
+
+- [ ] The new repo contains `.cursor/agents`, `.cursor/commands`, `.cursor/hooks`, `.cursor/skills`, `.mat/` (docs + tests + `AGENTS.mat.md`), `AGENTS.md`, and `.env.sample`.
+- [ ] Cursor recognizes the slash commands.
+- [ ] A first `/mat-prime` or `/mat-plan-team` prompt produces log files in `logs/`.
+- [ ] `docs/current-plan.md`, `build-result.md`, and `verify-result.md` are created during an orchestrated run.
+- [ ] Optional observability endpoints work if `apps/server` and `apps/client` were installed.

--- a/.mat/docs/phase4-roadmap-reassessment-checklist.md
+++ b/.mat/docs/phase4-roadmap-reassessment-checklist.md
@@ -1,0 +1,40 @@
+# Phase 4 — roadmap reassessment checklist (operator)
+
+**Purpose:** Bounded procedure for the ROADMAP **Current Focus** item *“Reassess blocked runtime limitations only when durable new evidence appears”* ([`ROADMAP.md`](../ROADMAP.md)). This is **operator work**, not something an unattended agent run can complete honestly.
+
+**Last updated:** 2026-03-29
+
+## Preconditions
+
+- You have a **pinned** Cursor version / build (note in the audit header).
+- You have read [`docs/decision-record.md`](decision-record.md) **Blocked remainder** and **Go criteria for the advisory slice** (G4–G7 measurement rows).
+- Procedures and PASS/INCONCLUSIVE definitions: [`docs/mao-advisory-go-criteria.md`](mao-advisory-go-criteria.md).
+- Audit template: [`../artifacts/phase1/mao-advisory-go-criteria-template.md`](../artifacts/phase1/mao-advisory-go-criteria-template.md).
+
+## Checklist
+
+1. **Restate current blocked claims** — From [`ROADMAP.md`](../ROADMAP.md) § *Blocked / Runtime-Limited*, copy the bullets that still apply (no deletion until evidence supports it).
+
+2. **Run or schedule measurement arms** — For each open G4–G7 item you intend to update, follow the matching section in [`docs/mao-advisory-go-criteria.md`](mao-advisory-go-criteria.md) (hook DB query, transcript search, grep for wording, tool vs manual arms). Record **PASS** or **INCONCLUSIVE** honestly.
+
+3. **Prepare evidence** — Agents may prepare evidence summaries, candidate diffs, or a prefilled audit template, but this remains operator-owned work until a human reviews the material.
+
+4. **File a redacted audit** — Add or update a row under `artifacts/phase1/` using the template; include Cursor version and whether `hook_events` / `artifacts/mao/*todo*` files appeared (**including explicit “none”**).
+
+5. **Update `docs/decision-record.md` checkboxes** — Only when you have **dated, cited** evidence from step 2–4. Do **not** check G4–G7 from inference or from another operator’s machine without a new audit row.
+
+6. **Update [`ROADMAP.md`](../ROADMAP.md)** — If posture changes, adjust *Current Focus* / *Near-Term* / *Blocked / Runtime-Limited* with one-line rationale and link to the audit file. Final roadmap or publication/packaging posture changes are operator-owned even when agents prepared the draft. If nothing changed, note “no change” in internal release notes or leave ROADMAP unchanged.
+
+7. **Repo verification** — Before merge: `bash scripts/phase1-verify.sh` and doc tests per [`docs/mao-advisory-go-criteria.md`](mao-advisory-go-criteria.md) G7.
+
+## Honesty boundaries
+
+- **Do not** claim authoritative live Cursor todo parity or a live dashboard todo column.
+- **Do not** claim hook-driven subagent spawn from **live** todo state.
+- **Do not** treat prepared evidence or drafted wording as runtime authority.
+- **INCONCLUSIVE** remains a valid outcome; it advances honesty without proving advisory usefulness.
+
+## Related
+
+- [`specs/phase-4-planning-session.md`](../specs/phase-4-planning-session.md) — Phase 4 direction.
+- [`docs/todo-orchestration-runtime-evidence.md`](todo-orchestration-runtime-evidence.md) — What committed artifacts can prove.

--- a/.mat/docs/templates/cost-hygiene-adoption.v1.json
+++ b/.mat/docs/templates/cost-hygiene-adoption.v1.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Devora-AS/multi-agent-teams/cost-hygiene-adoption.v1",
+  "title": "MAT cost & context hygiene — adoption record",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "bootstrap_mode",
+    "enforcement",
+    "selected_template",
+    "detection_reason"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "bootstrap_mode": {
+      "type": "string",
+      "enum": ["new-project", "existing-project"]
+    },
+    "enforcement": {
+      "type": "string",
+      "enum": ["strict", "warn_first"],
+      "description": "strict: CI/validator may fail on missing .cursorignore fragments. warn_first: existing-project adoption surfaces missing root fragments as WARN until opt-in strict; a full template is still installed when root `.cursorignore` was absent."
+    },
+    "selected_template": {
+      "type": "string",
+      "description": "Template key, e.g. default, node, python, rails, wordpress"
+    },
+    "detection_reason": {
+      "type": "string"
+    },
+    "detection_signals": {
+      "type": "object",
+      "additionalProperties": { "type": "boolean" }
+    },
+    "sidecar_suggest_writable": {
+      "type": "boolean",
+      "description": "Whether MAT was allowed to materialize *.mat-suggest under .mat/docs/templates/"
+    },
+    "root_cursorignore_preserved": {
+      "type": "boolean",
+      "description": "True when a root `.cursorignore` already existed and was left unchanged."
+    },
+    "root_cursorignore_created": {
+      "type": "boolean",
+      "description": "True when bootstrap wrote a new root `.cursorignore` because none was present."
+    }
+  }
+}

--- a/.mat/docs/templates/cursorignore-mat-default
+++ b/.mat/docs/templates/cursorignore-mat-default
@@ -1,0 +1,40 @@
+# MAT default .cursorignore — token/context hygiene for indexing @-mentions
+# Canonical copy lives here; repo root `.cursorignore` should stay aligned.
+# See: `.cursor/rules/cost-context-hygiene.mdc`, `scripts/validate_cost_context_hygiene_pack.py`
+
+# Dependencies & build outputs
+node_modules/
+dist/
+build/
+out/
+.next/
+.nuxt/
+.turbo/
+coverage/
+htmlcov/
+
+# Caches & compiled artifacts
+.cache/
+__pycache__/
+*.py[cod]
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/
+.tox/
+*.egg-info/
+
+# Logs & local env (never index secrets)
+*.log
+.env
+.env.*
+!.env.sample
+
+# Large generated / vendor trees (extend per repo)
+artifacts/run-traces/
+
+# ─── Escape hatch ─────────────────────────────────────────────────────────────
+# Tight ignores save tokens and reduce accidental secret exposure. When a slice
+# truly needs a path listed here (e.g. greenfield audit of build output, incident
+# response), remove or narrow the relevant lines in `.cursorignore` for that work,
+# document why in `docs/current-plan.md` or the session summary, and restore
+# strict patterns afterward. Do not permanently widen to "ignore nothing".

--- a/.mat/docs/templates/cursorignore-mat-default.mat-suggest
+++ b/.mat/docs/templates/cursorignore-mat-default.mat-suggest
@@ -1,0 +1,40 @@
+# MAT default .cursorignore — token/context hygiene for indexing @-mentions
+# Canonical copy lives here; repo root `.cursorignore` should stay aligned.
+# See: `.cursor/rules/cost-context-hygiene.mdc`, `scripts/validate_cost_context_hygiene_pack.py`
+
+# Dependencies & build outputs
+node_modules/
+dist/
+build/
+out/
+.next/
+.nuxt/
+.turbo/
+coverage/
+htmlcov/
+
+# Caches & compiled artifacts
+.cache/
+__pycache__/
+*.py[cod]
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/
+.tox/
+*.egg-info/
+
+# Logs & local env (never index secrets)
+*.log
+.env
+.env.*
+!.env.sample
+
+# Large generated / vendor trees (extend per repo)
+artifacts/run-traces/
+
+# ─── Escape hatch ─────────────────────────────────────────────────────────────
+# Tight ignores save tokens and reduce accidental secret exposure. When a slice
+# truly needs a path listed here (e.g. greenfield audit of build output, incident
+# response), remove or narrow the relevant lines in `.cursorignore` for that work,
+# document why in `docs/current-plan.md` or the session summary, and restore
+# strict patterns afterward. Do not permanently widen to "ignore nothing".

--- a/.mat/docs/templates/cursorignore-mat-node
+++ b/.mat/docs/templates/cursorignore-mat-node
@@ -1,0 +1,44 @@
+# MAT stack (Node/JS) .cursorignore — extends the MAT default ignore surface
+# Base block mirrors `docs/templates/cursorignore-mat-default` and `cursorignore-mat-shared.inc`
+# See: `.cursor/rules/cost-context-hygiene.mdc`
+
+# Dependencies & build outputs
+node_modules/
+dist/
+build/
+out/
+.next/
+.nuxt/
+.turbo/
+coverage/
+htmlcov/
+.storybook-out/
+storybook-static/
+.vercel/
+
+# Caches & compiled artifacts
+.cache/
+__pycache__/
+*.py[cod]
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/
+.tox/
+*.egg-info/
+
+# Logs & local env (never index secrets)
+*.log
+.env
+.env.*
+!.env.sample
+
+# Large generated / vendor trees (extend per repo)
+artifacts/run-traces/
+
+# Stack-specific (Node / bundlers)
+.parcel-cache/
+.eslintcache
+
+# ─── Escape hatch ─────────────────────────────────────────────────────────────
+# Tight ignores save tokens. Narrow or remove lines only for a named slice, document
+# the reason, and restore afterward. See `docs/templates/cursorignore-mat-default`.

--- a/.mat/docs/templates/cursorignore-mat-python
+++ b/.mat/docs/templates/cursorignore-mat-python
@@ -1,0 +1,49 @@
+# MAT stack (Python) .cursorignore — extends the MAT default ignore surface
+# Base block mirrors `docs/templates/cursorignore-mat-default` and `cursorignore-mat-shared.inc`
+# See: `.cursor/rules/cost-context-hygiene.mdc`
+
+# Dependencies & build outputs
+node_modules/
+dist/
+build/
+out/
+.next/
+.nuxt/
+.turbo/
+coverage/
+htmlcov/
+
+# Caches & compiled artifacts
+.cache/
+__pycache__/
+*.py[cod]
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/
+.tox/
+*.egg-info/
+.venv/
+venv/
+.uv/
+.python-version
+pip-wheel-metadata/
+
+# Logs & local env (never index secrets)
+*.log
+.env
+.env.*
+!.env.sample
+
+# Large generated / vendor trees (extend per repo)
+artifacts/run-traces/
+
+# Stack-specific (Python)
+*.egg
+*.whl
+wheels/
+site-packages/
+.ipynb_checkpoints/
+
+# ─── Escape hatch ─────────────────────────────────────────────────────────────
+# Tight ignores save tokens. Narrow or remove lines only for a named slice, document
+# the reason, and restore afterward. See `docs/templates/cursorignore-mat-default`.

--- a/.mat/docs/templates/cursorignore-mat-rails
+++ b/.mat/docs/templates/cursorignore-mat-rails
@@ -1,0 +1,46 @@
+# MAT stack (Rails) .cursorignore — extends the MAT default ignore surface
+# Base block mirrors `docs/templates/cursorignore-mat-default` and `cursorignore-mat-shared.inc`
+# See: `.cursor/rules/cost-context-hygiene.mdc`
+
+# Dependencies & build outputs
+node_modules/
+dist/
+build/
+out/
+.next/
+.nuxt/
+.turbo/
+coverage/
+htmlcov/
+
+# Caches & compiled artifacts
+.cache/
+__pycache__/
+*.py[cod]
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/
+.tox/
+*.egg-info/
+
+# Logs & local env (never index secrets)
+*.log
+.env
+.env.*
+!.env.sample
+
+# Large generated / vendor trees (extend per repo)
+artifacts/run-traces/
+
+# Stack-specific (Rails)
+tmp/
+log/
+storage/
+public/packs/
+public/assets/
+.byebug_history
+vendor/bundle/
+
+# ─── Escape hatch ─────────────────────────────────────────────────────────────
+# Tight ignores save tokens. Narrow or remove lines only for a named slice, document
+# the reason, and restore afterward. See `docs/templates/cursorignore-mat-default`.

--- a/.mat/docs/templates/cursorignore-mat-shared.inc
+++ b/.mat/docs/templates/cursorignore-mat-shared.inc
@@ -1,0 +1,39 @@
+# cursorignore-mat-shared.inc
+# Reusable block for MAT stack templates. When editing, sync copies in
+# `cursorignore-mat-default` and per-stack templates. Not installed at repo root
+# as-is; copied into `cursorignore-mat-*` files.
+
+# Dependencies & build outputs
+node_modules/
+dist/
+build/
+out/
+.next/
+.nuxt/
+.turbo/
+coverage/
+htmlcov/
+
+# Caches & compiled artifacts
+.cache/
+__pycache__/
+*.py[cod]
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/
+.tox/
+*.egg-info/
+
+# Logs & local env (never index secrets)
+*.log
+.env
+.env.*
+!.env.sample
+
+# Large generated / vendor trees (extend per repo)
+artifacts/run-traces/
+
+# ─── Escape hatch ─────────────────────────────────────────────────────────────
+# Tight ignores save tokens and reduce accidental secret exposure. When a slice
+# truly needs a path listed here, remove or narrow the relevant lines in
+# `.cursorignore` for that work, document why, and restore strict patterns afterward.

--- a/.mat/docs/templates/cursorignore-mat-wordpress
+++ b/.mat/docs/templates/cursorignore-mat-wordpress
@@ -1,0 +1,46 @@
+# MAT stack (WordPress) .cursorignore — extends the MAT default ignore surface
+# Base block mirrors `docs/templates/cursorignore-mat-default` and `cursorignore-mat-shared.inc`
+# See: `.cursor/rules/cost-context-hygiene.mdc`
+
+# Dependencies & build outputs
+node_modules/
+dist/
+build/
+out/
+.next/
+.nuxt/
+.turbo/
+coverage/
+htmlcov/
+
+# Caches & compiled artifacts
+.cache/
+__pycache__/
+*.py[cod]
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/
+.tox/
+*.egg-info/
+
+# Logs & local env (never index secrets)
+*.log
+.env
+.env.*
+!.env.sample
+
+# Large generated / vendor trees (extend per repo)
+artifacts/run-traces/
+
+# Stack-specific (WordPress)
+wp-content/uploads/
+wp-content/upgrade/
+wp-content/cache/
+wp-content/backup*/
+wp-content/debug.log
+*.sql
+*.wpress
+
+# ─── Escape hatch ─────────────────────────────────────────────────────────────
+# Tight ignores save tokens. Narrow or remove lines only for a named slice, document
+# the reason, and restore afterward. See `docs/templates/cursorignore-mat-default`.

--- a/.mat/docs/todo-orchestration-protocol.md
+++ b/.mat/docs/todo-orchestration-protocol.md
@@ -1,0 +1,340 @@
+# Todo orchestration protocol (MAO — Multi-Agent Orchestration)
+
+- **Purpose:** Strict, machine- and human-readable conventions for Cursor **To-dos** alongside file handoffs (`docs/current-plan.md`, `build-result.md`, `verify-result.md`).
+- **Audience:** Parent orchestrator, builder, verifier; operators using `/mat-plan-team` or equivalent.
+- **Status:** MVP (Phase 2 spike)
+- **Last updated:** 2026-03-27 (PostToolUse path extraction + SubagentStart root hardening)
+- **Rule:** [`.cursor/rules/orchestrator-todos.mdc`](../.cursor/rules/orchestrator-todos.mdc)
+
+## MVP scope
+
+| In scope | Out of scope (later) |
+|----------|----------------------|
+| Three-task convention + statuses + plan→build / build→validate dependencies | Live mirror of Cursor’s internal todo list UI (beyond MAO `MaoTransition` visibility in the observability dashboard) |
+| Orchestrator `.mdc` + agent/command alignment | Hook-driven auto-spawn on `TodoWrite` |
+| Deterministic `artifacts/mao/gate.json` after file writes to `docs/current-plan.md` or `build-result.md` (PostToolUse) | OS-level or hook-spawned verifier/mat-builder processes |
+| Opt-in hook `capture_transition_decision()` after handoff writes (`CURSOR_MAO_HOOK_AUTO_TRANSITION_CAPTURE=1`, requires `CURSOR_MAO_GATE` on + trusted fresh gate + non-empty `todo_mutations`; deduped) | Subagent spawn from Python hooks |
+| Opt-in gitignored `verifier-autostart-intent.json` after successful build→validate hook capture (`CURSOR_MAO_VERIFIER_AUTOSTART=1`) — parent still confirms and spawns verifier | Treating intent file as permission to skip explicit handoff checks |
+| Advisory `MAO_TASK_CONTEXT_JSON` prompt injection for builder/verifier subagents | Broader todo-transition automation |
+| `PostToolUse` records MAO todo observations (`todo-write-events.jsonl`, `last-todo-write-observation.json`) after normalized `todo_write` — traceability only | External task-board MCPs |
+| Hook-written `downstream-readiness.json` — deterministic `unblock_semantic` per MAO edge + optional todo observation cross-check (no `TodoWrite`, no auto-spawn); parent reads via `evaluate_parent_downstream_readiness_advisory()` (live vs on-disk trust); triggers include `transition_capture` and `hook_post_tool_use_auto_capture` | — |
+| `evaluate_mao_parent_transition_bundle()` + `interpret_unblock_semantic_for_parent()` — one-call decision + mutations + edge semantics for parents | — |
+| Observability dashboard **MAO visibility** panel — surfaces ingested `MaoTransition` events (WebSocket uses an enlarged payload preview for this type); opt-in **`CURSOR_MAO_EMIT_TRANSITION_OBSERVABILITY`** POSTs from hook auto-capture; advisory only | — |
+| File handoffs remain required and authoritative | — |
+
+## Task tags (required)
+
+Each orchestrated run uses **exactly three** todos. Every item **must** include its tag verbatim (including brackets) so roles and automation can scan without fuzzy parsing:
+
+| Tag | Role | Primary artifact | Logical dependency |
+|-----|------|------------------|-------------------|
+| `[mao:plan]` | Parent orchestrator | `docs/current-plan.md` | None |
+| `[mao:build]` | Builder | `build-result.md` | Plan complete |
+| `[mao:validate]` | Verifier | `verify-result.md` | Build complete |
+
+### Canonical content strings
+
+Use these **exact** strings for the todo `content` (single line):
+
+1. `[mao:plan] role:orchestrator | artifact:docs/current-plan.md`
+2. `[mao:build] role:builder | artifact:build-result.md | dep:plan`
+3. `[mao:validate] role:verifier | artifact:verify-result.md | dep:build`
+
+Optional suffix (human-readable only, after a space): short task title, e.g. ` — fix login bug`. The `[mao:…]` prefix must remain the **start** of the string.
+
+## Cursor statuses (semantic mapping)
+
+Map Cursor To-do statuses to orchestration semantics as follows:
+
+| Cursor status | Meaning in MAO |
+|---------------|----------------|
+| `pending` | Not started; waiting on dependency or orchestrator |
+| `in_progress` | Active for that role |
+| `completed` | Phase done; artifact present and accepted by that actor |
+| `cancelled` | User or orchestrator aborted; do not spawn downstream |
+
+### Default lifecycle
+
+1. **Orchestrator** creates all three todos. Initial state: `[mao:plan]` → `in_progress`; `[mao:build]` and `[mao:validate]` → `pending`.
+2. After `docs/current-plan.md` is written, the parent performs an explicit **plan→build transition check**. Only when that check is transition-ready may `[mao:plan]` move to `completed`, `[mao:build]` move to `in_progress`, and the builder be spawned.
+3. After builder finishes, the parent performs an explicit **build→validate transition check**. Only when that check is transition-ready may `[mao:build]` move to `completed`, `[mao:validate]` move to `in_progress`, and the verifier be spawned.
+4. After `verify-result.md` meets orchestrator gates: `[mao:validate]` → `completed`.
+
+### Pending advisory substates (gate-only)
+
+`artifacts/mao/gate.json` may add extra meaning for downstream MAO work that is still on Cursor status `pending`:
+
+| Cursor status | Advisory pending substate | Meaning |
+|---------------|---------------------------|---------|
+| `pending` | `blocked` | Canonical handoff evidence is still missing or insufficient. |
+| `pending` | `ready_for_parent_review` | Canonical handoff evidence looks transition-ready, but only the parent may do the explicit check and move real MAO state forward. |
+
+This does **not** introduce a new Cursor todo status. It is descriptive metadata only.
+
+### Parent consumption of `advisory_pending` (orchestration)
+
+`evaluate_plan_to_build_transition()` and `evaluate_build_to_validate_transition()` in [`mao_gate.py`](../.cursor/hooks/mao_gate.py) attach an **`advisory_pending` bundle** on every decision (in addition to the existing `gate` advisory reader result):
+
+| Field | Meaning |
+|-------|---------|
+| `live` | `advisory_pending` recomputed immediately from canonical files (`evaluate_mao_gate`) — always use this to understand **current** blocked vs `ready_for_parent_review` semantics. |
+| `from_gate_file` | Snapshot from `artifacts/mao/gate.json` when that file parses with **valid gate shape**; `null` when missing or invalid shape. |
+| `gate_file_shape_valid` | Whether the on-disk gate JSON had a full valid v2 shape (independent of “positive” / trusted preflight). |
+| `aligned_with_live` | `true` when `from_gate_file` matches `live` for both MAO tags; `false` when they disagree; `null` when there is no comparable file snapshot. |
+| `trusted_positive_gate_for_transition` | Same notion as a usable `read_parent_advisory_gate()` result for the transition under consideration. |
+| `interpretation` | Deterministic strings: how to treat the gate file for this transition, and a short summary of the **focus** downstream tag (`[mao:build]` for `plan_to_build`, `[mao:validate]` for `build_to_validate`). |
+
+**How the parent should use it**
+
+1. **Always** run the explicit canonical file transition checks first; the bundle does not replace them.
+2. Use **`live`** + **`interpretation`** to explain why `[mao:build]` / `[mao:validate]` should stay `pending`, what `recommended_parent_action` means, and which `blockers` the hook saw.
+3. Use **`trusted_positive_gate_for_transition`** only as support for `decision_mode: gate_plus_files`; weak or negative gate data implies manual/file fallback for advisory trust, not for canonical readiness.
+4. If `decision_mode` is `gate_plus_files` but **`aligned_with_live` is `false`**, treat the gate file as **contradictory** versus live handoffs: refresh the gate (e.g. re-save handoffs so hooks rewrite `gate.json`) or proceed using manual checks only. **`parent_owned_todo_mutations_for_transition()` returns no mutation** in that case even if canonical file checks passed — fail closed on todo mutations only, not on workflow progress (the parent can still move forward after manual review and a refreshed or ignored gate).
+
+`capture_transition_decision()` persists the same `advisory_pending` bundle on each `artifacts/mao/transition-events.jsonl` line for audits, and **surfaces supported todo mutations** on the same path: each appended line includes `todo_mutations`, `todo_mutations_applicable`, and `todo_mutations_blocked_reasons` derived from `parent_owned_todo_mutations_for_transition(decision)`. When the append succeeds, it also overwrites gitignored **`artifacts/mao/suggested-todo-mutation.json`** with a small summary the parent can read alongside the composer session. **Hooks still do not call `TodoWrite`**; the parent remains the only actor that applies Cursor todo state. If transition capture fails to append (IO error), no suggested file is written for that call; the parent can still run `evaluate_*_transition()` and `parent_owned_todo_mutations_for_transition()` in-process.
+
+### Opt-in PostToolUse transition capture (narrow automation)
+
+When **`CURSOR_MAO_HOOK_AUTO_TRANSITION_CAPTURE=1`**, [`post_tool_validate.py`](../.cursor/hooks/post_tool_validate.py) calls [`maybe_hook_auto_capture_transition()`](../.cursor/hooks/mao_gate.py) **after** `gate.json` refresh on writes to `docs/current-plan.md` or `build-result.md`. Hook capture **does not run** when **`CURSOR_MAO_GATE=0`** (implementation ties hook capture to the same trusted positive fresh gate machinery as the advisory slice). It calls the same `capture_transition_decision()` + evaluators; it skips when `todo_mutations` would be empty, when advisory `gate_plus_files` is misaligned vs live, or when the last `transition-events.jsonl` line for that transition already records the same handoff file mtimes (**dedupe**). Successful hook captures refresh **`downstream-readiness.json`** with `trigger: hook_post_tool_use_auto_capture` instead of `transition_capture`. Fail-open on errors.
+
+### Opt-in verifier dispatch intent (not auto-start)
+
+When **`CURSOR_MAO_VERIFIER_AUTOSTART=1`**, hooks may write gitignored **`artifacts/mao/verifier-autostart-intent.json`** only after a **successful build→validate hook auto-capture** in that PostToolUse chain, and only while canonical build→validate checks still pass on disk, `read_parent_advisory_gate(..., build_to_validate)` is usable, and `gate_is_fresh_on_disk` holds for the build handoff. Optional **`CURSOR_MAO_VERIFIER_AUTOSTART_REQUIRE_TODO_OBSERVATION=1`** additionally requires `last-todo-write-observation.json` to exist with `parse_quality: ok`. Minimal payload: `requested_at`, `transition`, `repo_root`, `mao_worktree`, `plan_mtime_epoch`, `build_mtime_epoch`, `reasons`. **“Autostart” names a conventional parent-owned review step** (not a guarantee of verifier dispatch): review the intent, apply `TodoWrite` if still needed, optionally spawn the verifier with `MAO_TASK_CONTEXT_JSON` when explicit build→validate checks pass, then delete or mark the intent consumed — hooks never start the verifier; the parent may still defer or skip dispatch for policy reasons.
+
+### Exact parent-owned transition mutations
+
+[`parent_owned_todo_mutations_for_transition()`](../.cursor/hooks/mao_gate.py) expresses the only helper-driven MAO status mutations allowed in this slice:
+
+- Passing `plan_to_build` decision => `[mao:plan]` `completed`, `[mao:build]` `in_progress`, `[mao:validate]` unchanged
+- Passing `build_to_validate` decision => `[mao:build]` `completed`, `[mao:validate]` `in_progress`, `[mao:plan]` unchanged
+- Blocked, unsupported, non-parent, or otherwise failed decisions => **no helper-driven mutation**
+- `decision_mode: gate_plus_files` **and** `advisory_pending.aligned_with_live === false` => **no helper-driven mutation** (contradictory on-disk `advisory_pending` vs live recompute; manual path or refresh gate first)
+
+The helper is intentionally conservative about ownership and transition readiness. If stale, invalid, contradictory, or negative gate evidence forces a fallback to manual/file-based review, the parent may still get the exact supported mutation after the explicit canonical-file transition check passes, **except** for the misaligned `gate_plus_files` case above.
+
+### Plan → build gate (strict)
+
+- `[mao:build]` **must not** be `in_progress` until `[mao:plan]` is `completed`.
+- The parent/orchestrator **owns** the transition decision; neither the hook gate nor plan-writing tool auto-advances MAO state.
+- Exact transition trigger: `docs/current-plan.md` exists, is not the repo placeholder, and is substantive enough to count as a real handoff.
+- If any part of that trigger is missing or not satisfied, the parent stays on manual review/file-based behavior and does **not** move build forward.
+- `parent_owned_todo_mutations_for_transition()` may translate a passing decision into the exact `[mao:plan]` / `[mao:build]` status changes above after either `gate_plus_files` or `manual_file_check`, but it returns no mutation for blocked, unsupported, or non-parent decisions.
+
+### Build → validate gate (strict)
+
+- `[mao:validate]` **must not** be `in_progress` until `[mao:build]` is `completed`.
+- The parent/orchestrator **owns** the transition decision; neither the hook gate nor the builder auto-advances MAO state.
+- Exact transition trigger: `docs/current-plan.md` is ready, `build-result.md` exists, the first declared build `Status` is **PASS** or **PARTIAL**, the `Acceptance Criteria` section contains only **PASS** / **PARTIAL** outcomes (no **FAIL**), and `Linting / Type-Check` is **PASS**.
+- If any part of that trigger is missing or not satisfied, the parent stays on manual review/file-based behavior and does **not** move validate forward.
+- `parent_owned_todo_mutations_for_transition()` may translate a passing decision into the exact `[mao:build]` / `[mao:validate]` status changes above after either `gate_plus_files` or `manual_file_check`, but it returns no mutation for blocked, unsupported, or non-parent decisions.
+
+## Role responsibilities
+
+### Parent orchestrator
+
+- Create/update all three todos via `TodoWrite` at orchestration start and at each transition.
+- Own `[mao:plan]` from `in_progress` → `completed`.
+- Move `[mao:build]` and `[mao:validate]` forward; never mark validate complete before verifier evidence exists.
+- Capture each explicit parent-owned transition decision alongside the file check, preferably via `capture_transition_decision()` in [`mao_gate.py`](../.cursor/hooks/mao_gate.py), so the decision is durably recorded without changing the canonical handoff flow. Prefer using the **`todo_mutations` field on the capture return value** (or the latest `suggested-todo-mutation.json` after a successful append) before calling `TodoWrite`, instead of recomputing mutations separately — both paths use the same `parent_owned_todo_mutations_for_transition()` rules.
+- When helper-driven MAO state updates are desired, use `parent_owned_todo_mutations_for_transition(decision)` or the `todo_mutations` from `capture_transition_decision()` to obtain the exact allowed mutations. A passing explicit parent transition check may yield the same mutation on either the advisory-gate or manual/file fallback path, unless `gate_plus_files` is paired with `advisory_pending.aligned_with_live === false`. Read `decision["advisory_pending"]["interpretation"]` when explaining pending work to the user. If the helper still returns `{}`, do not mutate MAO state from helper output.
+- To turn `todo_mutations` into a **`TodoWrite merge`** payload, use `apply_parent_todo_mutations_to_cursor_todos(todos, todo_mutations)` in [`mao_gate.py`](../.cursor/hooks/mao_gate.py): it matches each todo’s `content` by MAO tag prefix (protocol-allowed optional suffix after the canonical line is fine). Optionally call `validate_mao_todo_mutations_against_todos(todos, todo_mutations)` first; if it returns `ok: false`, skip `TodoWrite` and fix the list or handoffs. Optional CLI: [`scripts/mao-todo-write-merge.py`](../scripts/mao-todo-write-merge.py) (stdin JSON + `--from-suggested` or inline `todo_mutations`).
+
+### Parent transition bundle (single-call orchestration view)
+
+[`evaluate_mao_parent_transition_bundle()`](../.cursor/hooks/mao_gate.py) combines, for one edge (`plan_to_build` or `build_to_validate`):
+
+| Field | Purpose |
+|-------|---------|
+| `decision` | Full `evaluate_plan_to_build_transition()` or `evaluate_build_to_validate_transition()` output (includes `advisory_pending`). |
+| `todo_mutations` | Same map as `parent_owned_todo_mutations_for_transition(decision)`. |
+| `todo_mutations_blocked_reasons` | Deterministic reasons when mutations are `{}`. |
+| `edge_readiness` | Same per-edge record as inside `compute_mao_downstream_readiness()` (`unblock_semantic`, `transition_ready`, etc.). |
+| `unblock_semantic_interpretation` | From `interpret_unblock_semantic_for_parent()` — parent-facing meaning and `todo_mutations_expected`. |
+| `orchestration_flow_hint` | One-line tie-together for summaries (still not a substitute for explicit checks). |
+
+Optional `include_downstream_readiness_advisory=True` adds the full-file advisory (`live_snapshot`, `trusted_snapshot_for_hint`, …). Prefer this bundle when you would otherwise chain multiple `mao_gate` calls in the parent composer.
+
+### Parent-owned `unblock_semantic` values (downstream-readiness.json edges)
+
+Hook-written **`artifacts/mao/downstream-readiness.json`** labels each MAO edge with exactly one of:
+
+| `unblock_semantic` | Meaning (parent-owned) | Helper `todo_mutations` |
+|---------------------|-------------------------|-------------------------|
+| `downstream_blocked` | `transition_ready` is false for that edge. | Not applicable — `{}`. |
+| `unblocked_for_parent_action` | `transition_ready` true and mutation map non-empty. | Apply after explicit check. |
+| `ready_canonical_files_advisory_misaligned` | `transition_ready` true, `gate_plus_files`, `advisory_pending.aligned_with_live === false`. | Withheld `{}` until gate refresh or manual path. |
+| `transition_ready_uncertain_mutation_withheld` | `transition_ready` true but no mutation (rare shapes). | `{}` — manual review. |
+
+[`interpret_unblock_semantic_for_parent()`](../.cursor/hooks/mao_gate.py) expands each value into `meaning`, `parent_next`, and `todo_mutations_expected`. [`scripts/mao-downstream-readiness.py`](../scripts/mao-downstream-readiness.py) `--interpret-edges` attaches the same interpretation to `live_snapshot` edges for CLI use.
+
+### Builder
+
+- On start: set `[mao:build]` → `in_progress` (if not already).
+- On finish: write a truthful `build-result.md`, but leave the build→validate state transition to the parent. The builder does **not** set `[mao:build]` → `completed`; the parent does that only after the explicit transition check passes. On failure, leave `[mao:build]` as-is and document the outcome in `build-result.md` so the orchestrator can retry or cancel.
+- Do **not** mark `[mao:plan]` or `[mao:validate]`.
+
+### Verifier
+
+- On start: set `[mao:validate]` → `in_progress`.
+- On finish: set `[mao:validate]` → `completed` when `verify-result.md` is written with final outcome.
+- Do **not** mark `[mao:plan]` or `[mao:build]`.
+
+## SubagentStart MAO task context (advisory)
+
+Parent prompts for the builder and verifier may include one machine-readable line:
+
+```text
+MAO_TASK_CONTEXT_JSON: {"tag":"[mao:build]","role":"builder","primary_artifact":"build-result.md","handoff_inputs":["docs/current-plan.md"],"depends_on":"plan"}
+```
+
+or:
+
+```text
+MAO_TASK_CONTEXT_JSON: {"tag":"[mao:validate]","role":"verifier","primary_artifact":"verify-result.md","handoff_inputs":["docs/current-plan.md","build-result.md"],"depends_on":"build"}
+```
+
+### Minimal shape
+
+- `tag` — `[mao:build]` or `[mao:validate]`
+- `role` — `builder` or `verifier`
+- `primary_artifact` — `build-result.md` or `verify-result.md`
+- `handoff_inputs` — ordered list of the canonical file handoffs that subagent should read first
+- `depends_on` — optional dependency token (`plan` for build, `build` for validate)
+
+### Semantics
+
+- The marker is **advisory only**. It is meant for prompt clarity and for `subagentStart` hook parsing/logging.
+- File handoffs remain **canonical**: builder/verifier correctness still comes from `docs/current-plan.md`, `build-result.md`, and `verify-result.md`.
+- If the marker is missing, malformed, or unsupported, the subagent and hooks **must fail open** to the existing file-based workflow.
+- The marker does **not** authorize verifier auto-start, broader todo state transitions, or any replacement of the normal build→validate gate.
+
+### Optional `mao_worktree` inside `MAO_TASK_CONTEXT_JSON`
+
+Parents may add an optional object so subagent logs can record a **human-provided** label alongside hook-resolved workspace metadata:
+
+```text
+MAO_TASK_CONTEXT_JSON: {"tag":"[mao:build]","role":"builder","primary_artifact":"build-result.md","handoff_inputs":["docs/current-plan.md"],"depends_on":"plan","mao_worktree":{"label":"builder-agent"}}
+```
+
+- `mao_worktree.label` — non-empty string after trim; source recorded as `parent_prompt` in parsed `mao_task_context`.
+- If `mao_worktree` is missing, wrong type, or `label` is empty/invalid, the rest of the marker is still validated; invalid optional blocks are ignored (fail-open).
+- [`subagent_start.py`](../.cursor/hooks/subagent_start.py) always adds a top-level **`mao_worktree`** object on the logged payload: resolved `project_dir` (**`CURSOR_PROJECT_DIR` / `CLAUDE_PROJECT_DIR` when set, else first `workspace_roots` entry, else `cwd`** — aligned with `post_tool_validate`), optional `label` / `bootstrapped_at` from `.cursor/worktree/*` when the parallel worktree bootstrap ran, and `source` = `cursor_worktree_marker` or `absent` (see [`mao_worktree.py`](../.cursor/hooks/mao_worktree.py)).
+
+## MAO worktree metadata (protocol shape)
+
+Deterministic, advisory-only context shared across **`artifacts/mao/gate.json`**, **`artifacts/mao/transition-events.jsonl`** lines, and **`subagentStart`** logs:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `project_dir` | string | Resolved absolute path to the repo root used for the hook or transition |
+| `label` | string or null | Worktree name from `.cursor/worktree/name` when present |
+| `bootstrapped_at` | string or null | Timestamp text from `.cursor/worktree/bootstrapped_at` when present |
+| `source` | string | `cursor_worktree_marker` when `label` was read from disk; otherwise `absent` |
+
+Missing files, IO errors, or unknown payload shapes **never** block orchestration or hook exit codes. The parent remains the decision-maker; metadata is for traceability only.
+
+## Advisory gate file (`artifacts/mao/gate.json`)
+
+After a **file-writing** `PostToolUse` whose targets include `docs/current-plan.md` or `build-result.md`, [`post_tool_validate.py`](../.cursor/hooks/post_tool_validate.py) calls [`mao_gate.py`](../.cursor/hooks/mao_gate.py) to **re-read** canonical handoff files and write `artifacts/mao/gate.json` (gitignored) with:
+
+- `mao_worktree` — resolved worktree metadata for the project directory (same shape as the protocol table above).
+- `build_may_start` — `true` only when the plan is present, not the repo placeholder, and ready for the parent-owned `plan -> build` transition.
+- `validate_may_start` — `true` only when the plan is ready, `build-result.md` is present, the first declared `Status` line is **PASS** or **PARTIAL**, the `Acceptance Criteria` section contains no **FAIL**, and `Linting / Type-Check` is **PASS**.
+- `advisory_pending` — gate-only metadata for downstream pending MAO work, where `[mao:build]` / `[mao:validate]` stay on Cursor status `pending` while being described as either `blocked` or `ready_for_parent_review`, plus a `recommended_parent_action`, `primary_artifact`, and any blocking reasons.
+- `checks`, `reasons`, `inputs.plan_mtime_epoch` / `inputs.build_mtime_epoch` — for staleness checks vs disk.
+
+**Semantics:** Handoff files remain **authoritative**. The gate is a deterministic hint; orchestrators must still read `docs/current-plan.md` before spawning the builder and `build-result.md` before spawning the verifier. Treat the gate as usable advisory input only when it is **fresh, valid, internally consistent, and positive** for the specific transition being considered (`build_may_start: true` for `plan -> build`, `validate_may_start: true` for `build -> validate`, expected schema/version, coherent `checks`, coherent `advisory_pending`, and matching mtimes for the files that transition depends on). Even then, the parent still performs the exact file-based transition check above. If the gate is missing, disabled (`CURSOR_MAO_GATE=0`), stale, invalid, contradictory, or negative, use the same rules manually. `ready_for_parent_review` does **not** mean `in_progress`; it only means the parent has enough canonical evidence to review the transition. See [`artifacts/mao/README.md`](../artifacts/mao/README.md).
+
+## Transition decision capture (`artifacts/mao/transition-events.jsonl`)
+
+When the parent performs the explicit `plan -> build` or `build -> validate` transition check, it should also record that decision in gitignored `artifacts/mao/transition-events.jsonl` via `capture_transition_decision()` in [`mao_gate.py`](../.cursor/hooks/mao_gate.py). The capture helper **computes** `todo_mutations` with `parent_owned_todo_mutations_for_transition(decision)` and returns them on the Python result dict; you do not need a second call unless you are evaluating without capturing.
+
+Each append-only JSON line records:
+
+- `mao_worktree` — resolved worktree metadata at capture time (same shape as gate / protocol table).
+- `transition` — `plan_to_build` or `build_to_validate`
+- `allowed` — whether the parent decided the transition may proceed
+- `decision_owner` — `parent_orchestrator`
+- `decision_mode` — `gate_plus_files` or `manual_file_check`
+- `trigger_rule`, `reasons`, `manual_checks`
+- `todo_mutations`, `todo_mutations_applicable`, `todo_mutations_blocked_reasons` — supported MAO status deltas for `TodoWrite` when applicable; empty map with reasons when blocked or misaligned per protocol
+- `advisory` — whether the MAO gate was usable and why
+- `advisory_pending` — the same structured bundle attached to `evaluate_*_transition()` (`live`, `from_gate_file`, `aligned_with_live`, `interpretation`, …)
+- `files` — the handoff files and mtimes involved in the decision
+
+**Suggested mutation file:** When the JSONL append succeeds, `capture_transition_decision()` overwrites gitignored **`artifacts/mao/suggested-todo-mutation.json`** (versioned `file_version` field) with the same mutation summary for quick inspection or scripting. Optional CLI: [`scripts/mao-capture-transition.py`](../scripts/mao-capture-transition.py) from repo root.
+
+Optional observability emission may mirror the same transition payload to the Bun API as `event_type: MaoTransition`, but this is **fail-open only**: if the server is down, auth is missing, or validation fails, the parent still proceeds with the normal file-based workflow and local transition artifact capture remains non-blocking.
+
+## MAO todo-write observation (`PostToolUse`)
+
+When `PostToolUse` names normalize to **`todo_write`** (e.g. Cursor `TodoWrite`), [`post_tool_validate.py`](../.cursor/hooks/post_tool_validate.py) calls [`record_mao_todo_write_post_tool_observation()`](../.cursor/hooks/mao_gate.py), which **append-only** writes gitignored **`artifacts/mao/todo-write-events.jsonl`** and overwrites **`artifacts/mao/last-todo-write-observation.json`**.
+
+Each observation includes `parse_quality` (`ok`, `no_mao_tags`, `empty_todos`, `invalid_input`, `ambiguous_duplicate_tags`, `partial`), `mao_rows` when parsing succeeds, `parse_notes` for degraded or ambiguous cases, `mao_worktree`, and **`file_handoff_signals`** from `evaluate_mao_gate()` (or a skip reason when `CURSOR_MAO_GATE` is disabled). This is **not** a parent transition decision, does **not** call `TodoWrite`, and does **not** authorize subagent start. Stale, missing, or ambiguous todo payload fields fail open to manual/file review (`parse_quality` documents the gap, and `parse_notes` explain partial results). Disable all recording with `CURSOR_MAO_TODO_POST_TOOL_USE=0`. Optional `CURSOR_MAO_TODO_POST_TOOL_REFRESH_GATE=1` refreshes `gate.json` after an observation when `CURSOR_MAO_GATE` is on.
+
+## Downstream readiness snapshot (`artifacts/mao/downstream-readiness.json`)
+
+Hooks overwrite this gitignored file (when `CURSOR_MAO_DOWNSTREAM_READINESS` is on) after:
+
+- a successful `gate.json` refresh from a handoff write (`trigger`: `handoff_gate_refresh`),
+- a successful todo-write observation (`trigger`: `todo_write_post_tool_use`),
+- a handoff write while `CURSOR_MAO_GATE=0` (`trigger`: `handoff_post_tool_use_gate_disabled`).
+
+[`compute_mao_downstream_readiness()`](../.cursor/hooks/mao_gate.py) evaluates **`plan_to_build`** and **`build_to_validate`** the same way as the parent helpers and sets per-edge fields including `transition_ready`, `helper_todo_mutation_applicable`, and **`unblock_semantic`**:
+
+| `unblock_semantic` | Meaning |
+|--------------------|---------|
+| `downstream_blocked` | Canonical `transition_ready` is false for that edge. |
+| `unblocked_for_parent_action` | Canonical transition is ready **and** `parent_owned_todo_mutations_for_transition()` would return the supported mutation map (parent may apply `TodoWrite` after its explicit check). |
+| `ready_canonical_files_advisory_misaligned` | Canonical transition is ready but helper mutations are withheld because `decision_mode` is `gate_plus_files` and `advisory_pending.aligned_with_live` is false — refresh `gate.json` or use manual review before todo mutation. |
+| `transition_ready_uncertain_mutation_withheld` | Defensive bucket for unexpected shapes; treat as manual review. |
+
+The snapshot also includes **`todo_write_cross_check`**: when `last-todo-write-observation.json` exists, it compares recorded `file_handoff_signals` to live `evaluate_mao_gate()` booleans (`file_handoff_signals_match_live_gate` may be null when signals are absent). Missing, stale, or mismatched observation data does **not** change `unblock_semantic`; it only documents evidence quality.
+
+**Parent ownership:** Same as the gate file — files and explicit transition checks remain authoritative. Disable the artifact with `CURSOR_MAO_DOWNSTREAM_READINESS=0`.
+
+### Parent consumption of `downstream-readiness.json` (orchestration)
+
+[`evaluate_parent_downstream_readiness_advisory()`](../.cursor/hooks/mao_gate.py) is the supported parent entry point. It **always** returns a fresh **`live_snapshot`** (same computation as hook-written files) and, when `artifacts/mao/downstream-readiness.json` exists, includes **`from_artifact`** plus trust fields:
+
+| Field | Meaning |
+|-------|---------|
+| `downstream_readiness_enabled` | False when `CURSOR_MAO_DOWNSTREAM_READINESS` disables hook writes; live recompute is still returned for current edge semantics. |
+| `artifact_present` / `artifact_shape_ok` / `artifact_version_ok` | Whether a readable JSON object with expected edge keys exists and matches `DOWNSTREAM_READINESS_VERSION`. |
+| `artifact_aligned_with_live_edges` | `true` when on-disk `version` + `plan_to_build` + `build_to_validate` equal the live recompute; `false` when they differ (stale/tampered file); `null` when not comparable. |
+| `trusted_snapshot_for_hint` | `true` only when enabled, present, valid version, valid shape, **and** edges match live — then the file’s `unblock_semantic` is a reliable advisory hint alongside explicit checks. |
+| `reasons` | Machine codes (`artifact_missing`, `artifact_stale_or_divergent_from_live_edges`, …) when trust is withheld. |
+| `interpretation` | One deterministic sentence for operator summaries. |
+
+**How the parent should use it**
+
+1. **Never** skip `evaluate_plan_to_build_transition()` / `evaluate_build_to_validate_transition()` or canonical file reads because this helper returned `trusted_snapshot_for_hint: true`.
+2. Use **`live_snapshot`** when the file is missing, disabled, malformed, or **`trusted_snapshot_for_hint`** is false — live semantics are always authoritative for hints.
+3. When **`trusted_snapshot_for_hint`** is true, you may cite on-disk `unblock_semantic` in explanations to the user; still apply `capture_transition_decision()` / `todo_mutations` / explicit checks before `TodoWrite merge` or subagent dispatch.
+4. Optional CLI: [`scripts/mao-downstream-readiness.py`](../scripts/mao-downstream-readiness.py). Optional bundle with transition capture: `python3 scripts/mao-capture-transition.py <transition> --with-downstream-readiness`.
+
+## Hooks and blocking risk
+
+- **`postToolUse`:** Runs [`send_event.py`](../.cursor/hooks/send_event.py) (observability) and [`post_tool_validate.py`](../.cursor/hooks/post_tool_validate.py) (MAO gate refresh when `docs/current-plan.md` or `build-result.md` is touched — handoff detection uses expanded [`get_changed_files()`](../.cursor/hooks/post_tool_validate.py) path extraction; or **downstream-readiness** refresh when the gate is disabled but handoffs changed; **MAO todo observation** when the tool normalizes to `todo_write` via [`record_mao_todo_write_post_tool_observation()`](../.cursor/hooks/mao_gate.py); lint/typecheck after **file-writing** tools only).
+- **Todo / list tools:** Cursor exposes todo updates through tool calls whose names may vary by version (e.g. `TodoWrite`). Those names are **not** in `post_tool_validate.py`’s `WRITE_TOOLS` set, so **no project-wide ruff/tsc run** is triggered by todo updates. When the normalized tool is `todo_write`, hooks may append **`artifacts/mao/todo-write-events.jsonl`** and overwrite **`artifacts/mao/last-todo-write-observation.json`** with parsed MAO rows (when unambiguous), `mao_worktree`, and **`file_handoff_signals`** from `evaluate_mao_gate()` — advisory traceability only; disable with `CURSOR_MAO_TODO_POST_TOOL_USE=0`. **`failClosed` is false** for these hooks, so hook failures do not hard-block the editor.
+- **Evidence:** Todo updates still produce `PostToolUse` events that `send_event.py` forwards when the observability server is up (same as other tools).
+- **`subagentStart`:** [`subagent_start.py`](../.cursor/hooks/subagent_start.py) still logs the raw start payload, attaches resolved **`mao_worktree`** for the workspace root, and records a parsed `mao_task_context` field when the task text contains a valid `MAO_TASK_CONTEXT_JSON:` line (including optional parent `mao_worktree.label`). Invalid or absent task context is ignored for the parsed field only.
+
+### Committed vs local runtime proof
+
+Checked-in hook JSON under `artifacts/phase1/` still does **not** include a raw `PostToolUse` sample whose `tool_name` is a todo tool (e.g. `TodoWrite`). When Cursor **does** deliver todo-tool `PostToolUse` stdin to hooks, gitignored **`artifacts/mao/todo-write-events.jsonl`** and **`last-todo-write-observation.json`** record a deterministic interpretation (see **MAO todo-write observation** above). The repo also includes a **durable redacted session audit** at [`artifacts/phase1/todo-runtime-proof-20260327.md`](../artifacts/phase1/todo-runtime-proof-20260327.md): one live MAO `TodoWrite` sequence was executed, then the observability DB and transcript were checked for the same session. Details and regeneration steps live in [`todo-orchestration-runtime-evidence.md`](todo-orchestration-runtime-evidence.md).
+
+## Fallback
+
+If `TodoWrite` is unavailable: follow [`.cursor/agents/parent-orchestrator.md`](../.cursor/agents/parent-orchestrator.md) using **files only**; note the skip in `docs/session-summary.md`. Do not introduce a third-party task MCP.
+
+## Related docs
+
+- [todo-orchestration-mao-todowrite-application.md](todo-orchestration-mao-todowrite-application.md) — focused verification notes for parent `TodoWrite merge` helpers
+- [artifacts/mao/README.md](../artifacts/mao/README.md) — gate output directory (includes `downstream-readiness.json`)
+- [Events and visualization](events-and-visualization.md) — optional `MaoTransition` backend event
+- [Todo orchestration runtime evidence](todo-orchestration-runtime-evidence.md) — committed-artifact audit + local capture procedure
+- [Todo orchestration pilot](todo-orchestration-pilot.md) — minimal end-to-end check
+- [Orchestration workflow](orchestration-workflow.md)
+- [Decision record](decision-record.md) — Phase 2 criteria
+- [AGENTS.md](../AGENTS.md) — operator overview

--- a/.mat/docs/update-mat/advisor-task-session-summary.examples.json
+++ b/.mat/docs/update-mat/advisor-task-session-summary.examples.json
@@ -1,0 +1,79 @@
+[
+  {
+    "schema_version": "1.0.0",
+    "session_kind": "advisor",
+    "role": "architect",
+    "session_id": "advisor-2026-04-16-001",
+    "task_id": "update-mat-foundation",
+    "primary_artifact": "docs/update-mat/architecture-and-rollout.md",
+    "input_artifacts": [
+      "scripts/adoption/adoption-layout-v1.json",
+      "scripts/adoption/mat-footprint-v1.json"
+    ],
+    "decision": "Proceed with the Slice 1 foundation bundle and keep later slices out of scope.",
+    "status": "ready",
+    "summary": "The foundation documents and manifest give the updater a concrete contract for safe dry-run planning, compatibility analysis, and audit metadata without touching production repos.",
+    "risks": [
+      "The updater must keep preserve-path handling conservative.",
+      "Later rollout work is still pending and should not be implied by this slice."
+    ],
+    "follow_ups": [
+      "Wire the manifest into the CLI before enabling any broader rollout.",
+      "Keep the docs index aligned with the shipped files."
+    ],
+    "approvals": [
+      "operator_review_pending"
+    ],
+    "timestamp_utc": "2026-04-16T00:00:00Z",
+    "compatibility_snapshot": {
+      "manifest_name": "mat-target-footprint-v1",
+      "role_names": [
+        "updater",
+        "watcher",
+        "scanner",
+        "analyzer",
+        "architect",
+        "generator",
+        "test",
+        "ci",
+        "reviewer",
+        "security",
+        "rollback"
+      ]
+    }
+  },
+  {
+    "schema_version": "1.0.0",
+    "session_kind": "task",
+    "role": "scanner",
+    "session_id": "task-2026-04-16-017",
+    "task_id": "compatibility-scan",
+    "primary_artifact": "artifacts/update-mat/mat-plan-update-20260416T000000Z.json",
+    "input_artifacts": [
+      "scripts/adoption/mat-footprint-v1.json",
+      "docs/update-mat/role-prompt-templates.md"
+    ],
+    "decision": "Target footprint is readable and the role prompt bundle is concrete enough for a safe dry-run.",
+    "status": "partial",
+    "summary": "The scan confirmed the footprint manifest and prompt bundle can describe the target repo without implying that an apply step has happened.",
+    "risks": [
+      "The apply path still needs explicit operator approval.",
+      "Audit output must remain local to the sample or fixture repo."
+    ],
+    "follow_ups": [
+      "Run the updater against a fixture repo only.",
+      "Keep the validation report honest about the slice boundary."
+    ],
+    "approvals": [],
+    "timestamp_utc": "2026-04-16T00:00:00Z",
+    "compatibility_snapshot": {
+      "manifest_name": "mat-target-footprint-v1",
+      "preserve_paths": [
+        "README.md",
+        "AGENTS.md",
+        "build-result.md",
+        "verify-result.md"
+      ]
+    }
+  }
+]

--- a/.mat/docs/update-mat/advisor-task-session-summary.schema.json
+++ b/.mat/docs/update-mat/advisor-task-session-summary.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "docs/update-mat/advisor-task-session-summary.schema.json",
+  "title": "MAT advisor/task session summary",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "session_kind",
+    "role",
+    "session_id",
+    "task_id",
+    "primary_artifact",
+    "input_artifacts",
+    "decision",
+    "status",
+    "summary",
+    "risks",
+    "follow_ups",
+    "approvals",
+    "timestamp_utc"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1.0.0"]
+    },
+    "session_kind": {
+      "type": "string",
+      "enum": ["advisor", "task"]
+    },
+    "role": {
+      "type": "string",
+      "enum": ["updater", "watcher", "scanner", "analyzer", "architect", "generator", "test", "ci", "reviewer", "security", "rollback"]
+    },
+    "session_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "primary_artifact": {
+      "type": "string",
+      "minLength": 1
+    },
+    "input_artifacts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "decision": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["ready", "blocked", "partial", "done"]
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "follow_ups": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "approvals": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "timestamp_utc": {
+      "type": "string",
+      "minLength": 1
+    },
+    "compatibility_snapshot": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/.mat/docs/update-mat/architecture-and-rollout.md
+++ b/.mat/docs/update-mat/architecture-and-rollout.md
@@ -1,0 +1,99 @@
+# MAT updater architecture and rollout
+
+## Goal
+
+Slice 1 establishes a safe foundation for refreshing MAT-managed assets in adopted repositories without mutating real production targets. The updater remains dry-run first, audit-friendly, and explicit about what it may and may not touch.
+
+## Design principles
+
+- Treat project-owned `AGENTS.md` files as product content, not MAT-owned content.
+- Keep `.mat/` as the reference sidecar surface for packaged MAT material.
+- Prefer repository-native files and standard library Python over opaque automation.
+- Record every update attempt with enough metadata to reconstruct the decision.
+- Fail closed on ambiguous footprint or compatibility cases.
+
+## Cost & context hygiene (rollout note)
+
+MAT defaults include file-scoped context guidance (`.cursor/rules/cost-context-hygiene.mdc`), stack-aware `.cursorignore` templates under `docs/templates/cursorignore-mat-*` (mirrored under `.mat/docs/templates/` after bootstrap) with a shared `cursorignore-mat-shared.inc` block, install of the selected template when root `.cursorignore` is missing (**new-project** and **existing-project**), and `scripts/validate_cost_context_hygiene_pack.py` (structured severities, `--report`, `auto` enforcement from `.mat/cost-hygiene-adoption.json`, optional `CURSOR_MAT_COST_HYGIENE_ENFORCE`; template checks resolve `docs/templates/` or `.mat/docs/templates/` by basename) wired into `scripts/phase1-verify.sh`. **Existing-project** adoption writes `warn_first` and never overwrites an existing product `.cursorignore`; sidecar `*.mat-suggest` under `.mat/docs/templates/` supports optional merge review. Upstream refreshes should keep `adoption-layout-v1.json`, bootstrap, and the validator in sync so downstream repos do not silently lose the pack.
+
+## Contract layers
+
+1. **Source layout manifest**: `scripts/adoption/adoption-layout-v1.json` defines what the workflow repo packages into adopted repos (including `docs/workflow-artifact-contract.md` → `.mat/docs/workflow-artifact-contract.md` for the human-readable build/verify artifact contract; hooks prefer root `docs/` when present, else the sidecar copy).
+2. **Target footprint manifest**: `scripts/adoption/mat-footprint-v1.json` defines the preserve list, protected handoffs, doc bundle, and role contract for an adopted repo.
+3. **Updater contract module**: `scripts/adoption/update_mat_contracts.py` validates footprint manifests, loads JSON payloads, and serializes advisor summaries.
+4. **CLI updater**: `scripts/adoption/update-mat.py` keeps the operational flow, emits dry-run plan artifacts, and writes audit metadata. On **dry-run** (no `--apply`), it also attaches a **`legacy_cleanup_preview`** array to the plan JSON and prints a **Legacy cleanup preview** section to stdout: the same `apply_legacy_cleanup(..., dry_run=True)` decisions against the **target repo root** (no JSONL/quarantine writes from that pass; no audit-directory mkdir for legacy-only dry-run). Layout comparison treats paths listed in `mat-legacy-migrations-v1.json` as **allowed extras** inside MAT-owned trees so obsolete command files on the target do not spuriously conflict with upstream (they are surfaced only via the legacy preview).
+5. **Legacy migration manifest**: `scripts/adoption/mat-legacy-migrations-v1.json` lists obsolete MAT-managed files (for example old `.cursor/commands/*` names replaced by `mat-*` commands). Before processing, `validate_mat_legacy_migrations()` rejects invalid entries (schema, fingerprints, **`fingerprint_provenance`** on fingerprinted `backup_then_remove` / `auto_remove` rows, handling, successor shape, overlap with `preserve_paths` / `protected_handoff_paths`, or enumerated product-only root filenames). `scripts/adoption/apply_mat_legacy_cleanup.py` classifies each present file by **sha256** against known MAT fingerprints (for several commands, the manifest unions every distinct blob from `git log aefa9f7^ -- <path>` in this repo, plus the regression-test stub for `plan_w_team.md`). Exact match may be removed or quarantined per entry `handling`; customized content is not deleted (quarantine copy + keep original, or `warn_only`). Audit: `artifacts/update-mat/legacy-cleanup.jsonl` (machine-oriented fields per line: `run_id`, `manifest_schema_version`, `legacy_cleanup_jsonl_schema`, `action`, …); quarantine: `artifacts/update-mat/legacy-quarantine/<timestamp>/`. **Re-bootstrap** and **`update-mat.py --apply`** (staged worktree) run the applicator after new layout files are in place. Use `scripts/adoption/mat-legacy-fingerprints.py` to recompute or verify fingerprint unions against git history. **`--verify-all`** (also run from `scripts/phase1-verify.sh` when the script is present) checks every fingerprinted manifest entry in one pass, honoring each entry’s `fingerprint_provenance.boundary`. Use **`--strict`** when you want manifest-only hashes (for example test stubs) to fail the check; default lenient mode allows documented extras beyond git-only history.
+
+   **Coverage note (2026-06-22):** the shipped manifest now fingerprint-covers the remaining git-evidenced pre-`mat-*` slash commands under `.cursor/commands/` (`plan.md`, `plan_onboarding.md`, `doctor.md`, `lite.md`, `sprint.md`, `subagents_spawn.md`, `update_mat.md`, `check_worktrees.md`, plus earlier entries for `plan_w_team.md`, `build.md`, `review.md`, and `long-run.md`). **`plan-team.md`** remains `warn_only` without fingerprints. Agents, skills, hooks, and `output-styles/*` are not in scope.
+
+## Rollback / review (legacy cleanup)
+
+After refresh, inspect `artifacts/update-mat/legacy-cleanup.jsonl` (or `python3 scripts/adoption/apply_mat_legacy_cleanup.py --report`, or `bash doctor.sh --legacy-cleanup`). If entries show `quarantined_customized_left_in_place`, compare the repo file to the copy under `artifacts/update-mat/legacy-quarantine/.../customized-*`, merge any wanted edits into current MAT commands, then delete the legacy file manually if appropriate. To promote a path from `warn_only` to fingerprinted `backup_then_remove`, first capture git-derived hashes with `mat-legacy-fingerprints.py --path …`, merge into the manifest with evidence, then re-run verify. Removing the wrong file is avoided by fingerprint checks; restoring from quarantine is a simple file copy if you delete a stub by mistake.
+
+## Update flow
+
+1. Load the source layout and target footprint manifests.
+2. Resolve upstream source content and the adopted target root.
+3. Compare layout-driven MAT-managed files to the target repo.
+4. Analyze compatibility against the preserve list and protected handoff paths.
+5. Produce a dry-run plan and patch preview first, including the non-mutating legacy migration preview for the target tree.
+6. If the operator explicitly approves apply-mode staging, stage in an isolated worktree or branch-like path.
+7. Write audit metadata and stop before commit or PR creation.
+
+## Refresh vs re-bootstrap (operator mental model)
+
+| Mechanism | What it refreshes | What it intentionally preserves / avoids |
+|-----------|-------------------|----------------------------------------|
+| `update-mat.py` dry-run → optional `--apply` | Files the layout/footprint manifests classify as MAT-managed, with explicit conflict reporting | Product prose in root `AGENTS.md` / nested agent files except managed pointer blocks; does not silently rewrite unrelated product docs |
+| Re-run `bootstrap-workflow-into-repo.sh` | Full layout copy: `.cursor/`, packaged `scripts/`, `.mat/docs/`, `.mat/tests/`, `.mat/AGENTS.mat.md`, templates, `.env.sample`, cost-hygiene sidecar metadata | In `existing-project` mode: existing root `README.md`, `CHANGELOG.md`, `AGENTS.md`; existing `docs/current-plan.md` and `docs/long-run-state.md` when present; never overwrites an existing root `.cursorignore` |
+
+After either path, verify from the adopted repo root with `bash scripts/phase1-verify.sh` (and optionally your product CI). Review `.cursorignore` suggestions under `.mat/docs/templates/*.mat-suggest` when `warn_first` adoption applies.
+
+## Rollout phases
+
+### Slice 1
+
+- manifest-driven detection
+- compatibility analysis
+- dry-run planning
+- patch and plan artifact emission
+- audit metadata
+- role prompt templates
+- advisor/task-session summary schema
+- documentation bundle
+
+### Slice 2 (shipped)
+
+- CI wiring via standard `test_*.py` discovery in `scripts/phase1-verify.sh` (no separate hook)
+- integration harness: `tests/test_mat_updater_integration.py` (`MatUpdaterIntegrationTest`) calling `scripts/adoption/update-mat.py` in temp repos only
+- dry-run default, plan/patch artifact emission, AGENTS non-destructive handling, explicit `--apply` + `--approved` gates, no auto-commit regression lock
+- drift/conflict fail-closed regression locked (integration harness + `tests/test_update_mat.py`)
+- expanded `validation-report.md` with fast vs full updater verify commands
+
+### Slice 3 (shipped)
+
+- operator-facing validation report with end-to-end checklist ([`validation-report.md`](../../validation-report.md) slice 3)
+- adoption doc polish: [`docs/getting-started-existing-projects.md`](../getting-started-existing-projects.md), [`docs/getting-started-new-projects.md`](../getting-started-new-projects.md), [`docs/adoption-safe-defaults.md`](../adoption-safe-defaults.md), [`docs/MAINTAINER.md`](../MAINTAINER.md) (MAT updater operator runbook)
+- security posture documentation and `MatUpdaterSecurityDocsTest` regression locks in `tests/test_workflow_docs.py`
+- `specs/update-mat/tasks.json` TASK-001–005 complete
+
+## Security posture (slice 3)
+
+- **Fail-closed on drift and conflict:** target changes after dry-run or unresolved footprint/AGENTS ambiguity block apply; integration harness locks this in temp repos.
+- **No silent AGENTS overwrite:** product-owned `AGENTS.md` prose stays intact; the sidecar helper updates pointer blocks non-destructively.
+- **Temp-repo-only integration tests:** `MatUpdaterIntegrationTest` never mutates production adopted trees.
+- **Audit JSONL trail:** `artifacts/update-mat/legacy-cleanup.jsonl` and quarantine paths support rollback review.
+- **No auto-commit or auto-PR:** apply mode stages in a disposable worktree and stops before commit or PR creation.
+
+## Safety boundary
+
+This bundle does not:
+
+- update any production repository during automated tests
+- auto-commit or auto-open PRs
+- overwrite product-owned `AGENTS.md` prose silently
+- ship RFU-7 observability retention/redaction automation
+
+## Success criterion
+
+The first slice is shippable when the updater foundation can explain what it would change, why the change is compatible, and how to roll it back before any real mutation is approved.

--- a/.mat/docs/update-mat/index.md
+++ b/.mat/docs/update-mat/index.md
@@ -1,0 +1,56 @@
+# MAT updater foundation
+
+This bundle covers **slices 1–3** of the MAT updater + advisor coordination mission. The updater is dry-run first, audit-friendly, and explicit about what it may and may not touch. It does **not** auto-commit, auto-open PRs, or silently overwrite product-owned `AGENTS.md` prose.
+
+**Operator entry:** start with [`validation-report.md`](../../validation-report.md) (slice 3 checklist: dry-run → review → apply staging → manual commit decision).
+
+## Operator demo
+
+Run the recorded end-to-end walkthrough against a disposable temp adopted fixture:
+
+```txt
+bash scripts/demo/updater-operator-walkthrough.sh
+```
+
+The script bootstraps a temp repo, runs dry-run then `--apply --approved --plan-file`, asserts **no new commit** on the target root, and writes captured stdout plus artifact paths to [`artifacts/update-mat/demo-walkthrough-latest.md`](../../artifacts/update-mat/demo-walkthrough-latest.md) (gitignored). See [`validation-report.md`](../../validation-report.md) slice 3 Commands for verify commands and the operator checklist.
+
+## Contents
+
+- [`architecture-and-rollout.md`](architecture-and-rollout.md) — design for the updater foundation, compatibility checks, dry-run planning, staged rollout, slice boundaries, and security posture
+- [`role-prompt-templates.md`](role-prompt-templates.md) — role prompts for updater, watcher, scanner, analyzer, architect, generator, test, CI, reviewer, security, and rollback sessions
+- [`advisor-task-session-summary.schema.json`](advisor-task-session-summary.schema.json) — machine-readable summary schema for advisor/task session handoffs
+- [`advisor-task-session-summary.examples.json`](advisor-task-session-summary.examples.json) — example payloads that satisfy the schema
+- [`../../scripts/adoption/mat-footprint-v1.json`](../../scripts/adoption/mat-footprint-v1.json) — machine-readable target-repo MAT footprint manifest
+- [`../../scripts/adoption/mat-legacy-migrations-v1.json`](../../scripts/adoption/mat-legacy-migrations-v1.json) — legacy paths (e.g. pre-`mat-*` slash command filenames) and handling: `auto_remove` (fingerprint match only), `backup_then_remove`, or `warn_only`. **Fingerprints** are SHA256 of exact file bytes: for several legacy commands we list the union of every distinct blob from `git log aefa9f7^ -- <path>` in this repository (last revision before namespaced `mat-*` commands), plus the small stub bytes used in MAT's own regression tests for `plan_w_team.md`. Covered command examples include `plan_w_team.md`, `build.md`, `review.md`, `long-run.md`, `plan.md`, `plan_onboarding.md`, `doctor.md`, `lite.md`, `sprint.md`, `subagents_spawn.md`, `update_mat.md`, and `check_worktrees.md`; **`plan-team.md`** stays **`warn_only`** (no single canonical body). Agents, skills, hooks, and `output-styles/*` are out of scope for this manifest. Fingerprinted `backup_then_remove` / `auto_remove` entries carry **`fingerprint_provenance`** (`boundary`, `source`, `generated_at`, optional `note`) so CI and operators know how each union was produced (`git_log_union`, `git_log_union_plus_stub`, or `manual`). Anything whose bytes are **not** in that set is treated as customized — quarantine copy, original retained — not deleted. The manifest is **validated** before any applicator run: blocked paths overlap `preserve_paths` / `protected_handoff_paths`, enumerated product-only root filenames, malformed fingerprints, missing provenance on fingerprinted entries, unknown `handling`, or `backup_then_remove` / `auto_remove` without fingerprints cause a hard error (operators must not ship invalid manifests).
+- [`../../scripts/adoption/mat-legacy-fingerprints.py`](../../scripts/adoption/mat-legacy-fingerprints.py) — operator helper: default `git log aefa9f7^ -- <path>` walks; prints a sorted SHA256 union of historical file bodies for `--path`. **`--verify`** checks that every git-derived blob for that path appears in the checked-in manifest (exit non-zero if git has undocumented bytes); uses per-entry `fingerprint_provenance.boundary` when set. **`--verify-all`** runs that check for every manifest entry with non-empty fingerprints (wired into `scripts/phase1-verify.sh` on the **MAT source** profile where this repo's git history is available). **`--strict`** additionally fails when the manifest lists hashes not seen in that git slice (useful for catching typos; off by default so documented test stubs may exceed git-only history).
+- [`../../scripts/adoption/apply_mat_legacy_cleanup.py`](../../scripts/adoption/apply_mat_legacy_cleanup.py) — applies that manifest, appends `artifacts/update-mat/legacy-cleanup.jsonl`, and quarantines under `artifacts/update-mat/legacy-quarantine/<run-id>/` when needed. Manifest entries must not name `mat-footprint-v1.json` preserve/protected paths (validation rejects them). Each JSONL record includes `run_id`, `manifest_schema_version`, and `legacy_cleanup_jsonl_schema` for audit correlation. **`--report`** prints a stdout summary of the latest `run_id` slice; **`bash doctor.sh --legacy-cleanup`** runs the same report from the repo root.
+- **`update-mat.py` dry-run** runs the same legacy engine against the **adopted target tree** with `dry_run=True` (no JSONL append, no quarantine writes, no `artifacts/update-mat/` directory creation from the legacy applicator alone) and records structured decisions under `legacy_cleanup_preview` in the plan JSON and in the human-readable plan/patch stdout section (`would_remove`, `would_quarantine_and_remove`, `would_quarantine_customized`, `warn_only`, `skipped_preserve_paths`, `skipped_absent`, `skipped_customized`, `skipped_not_file`, etc., matching `apply_mat_legacy_cleanup` action names). Apply mode still runs real cleanup on the staging worktree after layout copy.
+
+## Cost & context hygiene pack (MAT default)
+
+Bootstrap and `scripts/phase1-verify.sh` ship an **enforced pack**: always-on [`.cursor/rules/cost-context-hygiene.mdc`](../../.cursor/rules/cost-context-hygiene.mdc), root [`.cursorignore`](../../.cursorignore) (stack-detected template from [`docs/templates/`](../../docs/templates/) in the MAT source tree; in adopted repos templates also live under `.mat/docs/templates/`), [`scripts/validate_cost_context_hygiene_pack.py`](../../scripts/validate_cost_context_hygiene_pack.py) (structured `FAIL`/`WARN`/`INFO`, `--report`, `--enforce auto|strict|warn_first` reading `.mat/cost-hygiene-adoption.json` when present; validator resolves each template from `docs/templates/<name>` or `.mat/docs/templates/<name>`), and optional `bash doctor.sh --cost-hygiene`. **New-project** installs the selected template when root `.cursorignore` is missing. **Existing-project** runs set `warn_first` in the adoption file: they **never overwrite** an existing product `.cursorignore`; when root `.cursorignore` is absent, they install the same stack-detected template as new-project. Use **`CURSOR_MAT_COST_HYGIENE_ENFORCE=strict`** in downstream CI to opt into a hard-fail until fragments match. `artifacts/cost-hygiene/` (from `--report`) is local, gitignored, advisory only — not billing. Re-bootstrap or copy those paths when refreshing an adopted repo; CI fails if the pack is gutted (unless only WARN under warn-first and no FAIL).
+
+## Workflow artifact contract (dual location)
+
+`build-result.md` and `verify-result.md` must follow the same section contract as the MAT source file `docs/workflow-artifact-contract.md`. In adopted repositories that contract is also copied to **`.mat/docs/workflow-artifact-contract.md`**; bootstrap adjusts `.cursor/` prompts so links do not assume a bulk-copied root `docs/` tree. Runtime validation resolves the readable doc from root `docs/` first, then `.mat/docs/`.
+
+**Source-only vs adopted:** the full MAT **source** repository keeps broad `docs/`, `specs/`, `apps/`, and the primary `tests/` suite. Adopted repos get **minimal** root `docs/` (typically `current-plan.md` and `long-run-state.md` only), packaged manuals under **`.mat/docs/`**, contract tests under **`.mat/tests/`**, and `scripts/phase1-verify.sh` runs the **adopted** profile when `.mat/README.md` is present (optional handoff validation, `.mat/tests` unittest target, skips Bun smoke without `apps/server`).
+
+## Adoption observability
+
+- [`adoption-observability-appendix.md`](../adoption-observability-appendix.md) — opt-in observability posture for product repos: enablement, `events.sqlite`, manual rotation, gitignore surfaces, preview-vs-full-row honesty, hook capture dirs, RFU-7 deferral link, and a README checklist. Copied to **`.mat/docs/adoption-observability-appendix.md`** on bootstrap/update via `adoption-layout-v1.json`.
+- Maintainer depth: [`observability-retention-policy.md`](../observability-retention-policy.md).
+
+## Slice boundary
+
+| Slice | Shipped scope |
+| --- | --- |
+| **1** | Footprint manifest, role prompts, summary schema, dry-run planning, patch/plan artifacts |
+| **2** | CI-visible integration harness (`MatUpdaterIntegrationTest`), temp-repo regression locks, fast/full verify commands |
+| **3** | Operator validation report checklist, adoption doc polish, security doc locks (`MatUpdaterSecurityDocsTest`) |
+
+**Not shipped (honest non-goals):**
+
+- Auto-commit or auto-PR creation
+- Silent overwrite of product-owned `AGENTS.md` prose
+- RFU-7 observability retention/redaction automation

--- a/.mat/docs/update-mat/role-prompt-templates.md
+++ b/.mat/docs/update-mat/role-prompt-templates.md
@@ -1,0 +1,123 @@
+# MAT updater role prompt templates
+
+These templates are intentionally concise. Each role should read the relevant manifest and the architecture doc first, then publish a structured handoff instead of a raw transcript.
+
+When a role drafts a prompt or handoff example, default to copy-pasteable fenced `txt` blocks unless another format is requested.
+
+## Updater
+
+You are the MAT updater. Detect upstream drift, compare it to the target footprint, produce a dry-run plan, and stop before any real mutation unless explicit approval is present.
+
+Required inputs:
+
+- `scripts/adoption/adoption-layout-v1.json`
+- `scripts/adoption/mat-footprint-v1.json`
+- target repo root
+
+Required output:
+
+- compatibility snapshot
+- dry-run plan
+- patch preview
+- audit metadata
+
+## Watcher
+
+You are the watcher. Observe upstream MAT releases, tags, or commits and report only the material drift that affects the footprint manifest.
+
+Required output:
+
+- source ref observed
+- drift summary
+- any release or tag candidates worth reviewing
+
+## Scanner
+
+You are the scanner. Inspect the target repo structure and report what MAT-owned and project-owned surfaces are present before any update attempt.
+
+Required output:
+
+- discovered footprint
+- missing expected files
+- unexpected files inside protected areas
+
+## Analyzer
+
+You are the analyzer. Compare the upstream and target footprints, classify compatibility, and explain whether the dry-run is safe to stage.
+
+Required output:
+
+- compatibility verdict
+- preserve-path conflicts
+- protected handoff conflicts
+- follow-up recommendation
+
+## Architect
+
+You are the architect. Turn the updater contracts into a rollout plan that keeps product-owned `AGENTS.md` files intact and respects `.mat/` sidecar semantics.
+
+Required output:
+
+- architecture summary
+- rollout phase boundary
+- safety assumptions
+
+## Generator
+
+You are the generator. Produce operator-ready artifacts such as plan previews, patch previews, and concise change summaries from the contract outputs.
+
+Required output:
+
+- generated artifact path
+- summary of what the artifact proves
+- any truncation or caveats
+
+## Test
+
+You are the test role. Add or refine focused regression coverage for the updater contract, summary schema, and no-write safety guarantees.
+
+Required output:
+
+- test cases added or updated
+- commands used
+- explicit pass/fail evidence
+
+## CI
+
+You are the CI role. Check whether the slice is actually shippable in the repo's validation environment and call out any missing prerequisites.
+
+Required output:
+
+- validation command matrix
+- pass/fail result
+- environment gaps
+
+## Reviewer
+
+You are the reviewer. Evaluate the updater slice for honesty, safety, and whether the docs and contract files match the implementation.
+
+Required output:
+
+- findings ordered by severity
+- contract mismatches
+- remaining slice boundaries
+
+## Security
+
+You are the security role. Review the updater for silent overwrite risk, approval bypasses, and any path handling that could escape the intended footprint.
+
+Required output:
+
+- path handling risks
+- approval gate risks
+- rollback concerns
+
+## Rollback
+
+You are the rollback role. Explain how to back out a staged MAT update safely without damaging product-owned files.
+
+Required output:
+
+- rollback path
+- backup path
+- any limitations that require manual intervention

--- a/.mat/docs/workflow-artifact-contract.md
+++ b/.mat/docs/workflow-artifact-contract.md
@@ -1,0 +1,123 @@
+# Workflow Artifact Contract
+
+**Status:** canonical Phase 1 contract for workflow handoff artifacts
+
+**Purpose:** define the required structure for `build-result.md` and `verify-result.md` so prompts, command docs, validators, MAO parsing, and tests all point at the same contract.
+
+## Source Of Truth
+
+This contract has two layers:
+
+1. **Runtime source of truth:** `.cursor/hooks/artifact_contract.py`
+2. **Human-readable reference:** this document
+
+**Where this file lives:** In the MAT **source** repository, the human-readable copy is here at `docs/workflow-artifact-contract.md`. When MAT is **bootstrapped** into another repo, the same text is packaged under **`.mat/docs/workflow-artifact-contract.md`** so product-owned root `docs/` can stay minimal. Hooks and validators resolve the readable contract with `resolve_workflow_artifact_contract_doc(repo_root)` (prefer root `docs/` when present, else `.mat/docs/`). Prompts under `.cursor/` in the source tree link to `../../docs/workflow-artifact-contract.md`; bootstrap rewrites those links in the adopted tree to `../../.mat/docs/workflow-artifact-contract.md` and normalizes inline `docs/workflow-artifact-contract.md` path strings under `.cursor/` to `.mat/docs/workflow-artifact-contract.md`.
+
+The runtime layer owns the enforceable rules used by:
+
+- `.cursor/scripts/validate_artifacts.py` (supports `--optional-handoff-artifacts` for MAT **adopted** trees where `build-result.md` / `verify-result.md` exist only during an active slice; `scripts/phase1-verify.sh` passes this flag when `.mat/README.md` is present)
+- `.cursor/hooks/mao_gate.py`
+- regression tests under `tests/`
+
+Prompt and command examples must mirror this document and the shared runtime module exactly. If the runtime module changes, update this document and every prompt/example in the same slice.
+
+## Build Result Contract
+
+`build-result.md` must use this structure:
+
+```markdown
+# Build Result
+
+## Task
+<one-line description>
+
+## Status
+PASS | FAIL | PARTIAL
+
+## Changes Made
+- `path/to/file.py`: <what changed and why>
+
+## Acceptance Criteria
+- Criterion 1: PASS — <brief evidence>
+- Criterion 2: FAIL — <reason>
+
+## Linting / Type-Check
+PASS | FAIL
+<optional supporting detail lines>
+
+## Issues / Blockers
+None | <open issues>
+
+## Notes for Verifier
+<specific guidance for verification>
+
+## Closeout (YYYY-MM-DD)
+<brief closeout summary>
+```
+
+### Build rules
+
+- `## Status` must start with `PASS`, `FAIL`, or `PARTIAL`.
+- `## Changes Made` must contain at least one non-empty entry.
+- `## Acceptance Criteria` must contain bullet lines, and every bullet must include `: PASS`, `: FAIL`, or `: PARTIAL`.
+- `## Linting / Type-Check` must start with `PASS` or `FAIL`.
+- `## Issues / Blockers`, `## Notes for Verifier`, and `## Closeout (YYYY-MM-DD)` must not be empty.
+- The closeout heading must use an ISO date.
+
+### MAO build-to-validate dependency
+
+The MAO gate reads the same contract. A build artifact is only transition-ready for validate when:
+
+- the build contract is structurally valid
+- `## Status` starts with `PASS` or `PARTIAL`
+- every acceptance-criteria bullet resolves to `PASS` or `PARTIAL`
+- `## Linting / Type-Check` starts with `PASS`
+
+## Verify Result Contract
+
+`verify-result.md` must use this structure:
+
+```markdown
+# Verify Result
+
+## Plan
+docs/current-plan.md
+
+## Builder Result
+build-result.md
+
+## Status
+PASS | FAIL | PARTIAL
+
+## Criteria Review
+
+### Criterion 1: <text from plan>
+**Result:** PASS | FAIL | PARTIAL
+**Evidence:** `path/to/file.py:42` — <relevant evidence>
+
+## Issues Found
+None | <issues with file and line references>
+
+## Recommendations
+None | <specific next actions>
+
+## Closeout (YYYY-MM-DD)
+<brief verification closeout summary>
+```
+
+### Verify rules
+
+- `## Status` must start with `PASS`, `FAIL`, or `PARTIAL`.
+- `## Criteria Review` must contain at least one `### Criterion ...` block.
+- Every criterion block must include a non-empty `**Result:**` line and a non-empty `**Evidence:**` line.
+- `## Plan`, `## Builder Result`, `## Issues Found`, `## Recommendations`, and `## Closeout (YYYY-MM-DD)` must not be empty.
+- The closeout heading must use an ISO date.
+
+## Change Discipline
+
+When touching this contract:
+
+- update `.cursor/hooks/artifact_contract.py`
+- update prompt and command examples in the same change
+- update validator and MAO tests in the same change
+- run the workflow validation commands before claiming the contract is aligned

--- a/.mat/tests/test_artifact_validation.py
+++ b/.mat/tests/test_artifact_validation.py
@@ -1,0 +1,627 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    """Resolve repo root whether tests live in tests/ or .mat/tests/ (adopted repos)."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / ".cursor" / "hooks.json").is_file():
+            return parent
+    return here.parents[1]
+
+
+REPO_ROOT = _repo_root()
+VALIDATOR_PATH = REPO_ROOT / ".cursor" / "scripts" / "validate_artifacts.py"
+VERIFY_SCRIPT = REPO_ROOT / "scripts" / "phase1-verify.sh"
+
+_MODULE_NAME = "validate_artifacts_test_harness"
+_SPEC = importlib.util.spec_from_file_location(_MODULE_NAME, VALIDATOR_PATH)
+assert _SPEC and _SPEC.loader
+_VALIDATOR = importlib.util.module_from_spec(_SPEC)
+sys.modules[_MODULE_NAME] = _VALIDATOR
+_SPEC.loader.exec_module(_VALIDATOR)
+
+
+def _load_artifact_contract_module():
+    import importlib.util
+
+    mod_path = REPO_ROOT / ".cursor" / "hooks" / "artifact_contract.py"
+    name = "_artifact_contract_test"
+    spec = importlib.util.spec_from_file_location(name, mod_path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _minimal_current_plan() -> str:
+    return textwrap.dedent(
+        """\
+        # Current plan
+
+        ## DoR
+
+        - Work the current slice only.
+
+        ## Non-goals
+
+        - No unrelated edits.
+        """
+    )
+
+
+def _minimal_build_result() -> str:
+    return textwrap.dedent(
+        """\
+        # Build Result
+
+        ## Task
+        Validate the slice.
+
+        ## Status
+        PASS
+
+        ## Changes Made
+        - `docs/workflow-artifact-contract.md`: defines the canonical contract.
+
+        ## Acceptance Criteria
+        - Criterion 1: PASS — contract sections are present
+
+        ## Linting / Type-Check
+        PASS
+
+        ## Issues / Blockers
+        None
+
+        ## Notes for Verifier
+        Inspect the shared contract consumers.
+
+        ## Closeout (2026-03-29)
+
+        Ready for verification.
+        """
+    )
+
+
+def _minimal_verify_result() -> str:
+    return textwrap.dedent(
+        """\
+        # Verify Result
+
+        ## Plan
+        docs/current-plan.md
+
+        ## Builder Result
+        build-result.md
+
+        ## Status
+        PASS
+
+        ## Criteria Review
+
+        ### Criterion 1: contract sections are present
+        **Result:** PASS
+        **Evidence:** `docs/workflow-artifact-contract.md` lists the required sections.
+
+        ## Issues Found
+        None
+
+        ## Recommendations
+        None
+
+        ## Closeout (2026-03-29)
+
+        Verified.
+        """
+    )
+
+
+def _minimal_long_run_state(last_updated: str = "2026-03-29") -> str:
+    return textwrap.dedent(
+        f"""\
+        # Long-run mission state
+
+        **Last updated:** {last_updated}
+
+        ## Mission
+
+        - **Goal:** Keep the validator deterministic.
+        - **execution_mode:** `long-run`
+
+        ## Parent mission gate compliance
+
+        - [ ] Capture the parent decision.
+        """
+    )
+
+
+class ValidateArtifactsTest(unittest.TestCase):
+    def test_valid_minimal_artifacts_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _write(root / "docs" / "current-plan.md", _minimal_current_plan())
+            _write(root / "build-result.md", _minimal_build_result())
+            _write(root / "verify-result.md", _minimal_verify_result())
+            _write(root / "docs" / "long-run-state.md", _minimal_long_run_state())
+
+            result = _VALIDATOR.validate_paths(_VALIDATOR.default_repo_paths(root))
+
+            self.assertTrue(result.ok(), msg=_VALIDATOR.format_issues(result))
+
+    def test_optional_handoff_artifacts_skips_missing_build_verify(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _write(root / "docs" / "current-plan.md", _minimal_current_plan())
+            _write(root / "docs" / "long-run-state.md", _minimal_long_run_state())
+            paths = _VALIDATOR.default_repo_paths(root)
+            paths.pop("build_result", None)
+            paths.pop("verify_result", None)
+
+            result = _VALIDATOR.validate_paths(paths)
+
+            self.assertTrue(result.ok(), msg=_VALIDATOR.format_issues(result))
+
+    def test_cli_optional_handoff_allows_missing_handoffs(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _write(root / "docs" / "current-plan.md", _minimal_current_plan())
+            _write(root / "docs" / "long-run-state.md", _minimal_long_run_state())
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(VALIDATOR_PATH),
+                    "--repo-root",
+                    str(root),
+                    "--require-current-plan",
+                    "--optional-handoff-artifacts",
+                ],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            self.assertEqual(completed.returncode, 0, msg=completed.stdout + completed.stderr)
+
+    def test_missing_required_file_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing = Path(temp_dir) / "docs" / "long-run-state.md"
+
+            result = _VALIDATOR.validate_paths({"long_run_state": missing})
+
+            self.assertFalse(result.ok())
+            self.assertEqual(
+                [(issue.code, issue.message) for issue in result.issues],
+                [("missing", "file does not exist")],
+            )
+
+    def test_current_plan_requires_non_goals(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plan = Path(temp_dir) / "docs" / "current-plan.md"
+            _write(
+                plan,
+                "# Current plan\n\n## DoR\n\n- Missing non-goals on purpose.\n",
+            )
+
+            result = _VALIDATOR.validate_paths({"current_plan": plan})
+
+            self.assertFalse(result.ok())
+            self.assertIn(("non_goals", "missing '## Non-goals' subsection"), {
+                (issue.code, issue.message) for issue in result.issues
+            })
+
+    def test_current_plan_requires_closeout_when_requested(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plan = Path(temp_dir) / "docs" / "current-plan.md"
+            _write(plan, _minimal_current_plan())
+
+            result = _VALIDATOR.validate_paths(
+                {"current_plan": plan},
+                require_current_plan_closeout=True,
+            )
+
+            self.assertFalse(result.ok())
+            self.assertIn(("closeout_section", "missing '## Closeout' subsection"), {
+                (issue.code, issue.message) for issue in result.issues
+            })
+
+    def test_trailing_whitespace_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plan = Path(temp_dir) / "docs" / "current-plan.md"
+            _write(
+                plan,
+                "# Current plan\n\n## Non-goals\n\n- This line has trailing spaces.   \n",
+            )
+
+            result = _VALIDATOR.validate_paths({"current_plan": plan})
+
+            self.assertFalse(result.ok())
+            self.assertIn(("trailing_whitespace", "line 5: trailing whitespace"), {
+                (issue.code, issue.message) for issue in result.issues
+            })
+
+    def test_long_run_requires_mission_execution_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            long_run = Path(temp_dir) / "docs" / "long-run-state.md"
+            _write(
+                long_run,
+                textwrap.dedent(
+                    """\
+                    # Long-run mission state
+
+                    **Last updated:** 2026-03-29
+
+                    ## Mission
+
+                    - **Goal:** Missing execution mode on purpose.
+
+                    ## Parent mission gate compliance
+
+                    - [ ] Gate entry exists.
+                    """
+                ),
+            )
+
+            result = _VALIDATOR.validate_paths({"long_run_state": long_run})
+
+            self.assertFalse(result.ok())
+            self.assertIn(
+                (
+                    "execution_mode",
+                    "missing mission-level **execution_mode:** `short-run` or `long-run`",
+                ),
+                {(issue.code, issue.message) for issue in result.issues},
+            )
+
+    def test_long_run_accepts_parenthetical_mission_gate_heading(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            long_run = Path(temp_dir) / "docs" / "long-run-state.md"
+            _write(
+                long_run,
+                textwrap.dedent(
+                    """\
+                    # Long-run mission state
+
+                    **Last updated:** 2026-03-29
+
+                    ## Mission
+
+                    - **Goal:** Accept current repo heading style.
+                    - **execution_mode:** `long-run`
+
+                    ## Parent mission gate compliance (per verifier PASS)
+
+                    - [ ] Gate entry exists.
+                    """
+                ),
+            )
+
+            result = _VALIDATOR.validate_paths({"long_run_state": long_run})
+
+            self.assertTrue(result.ok(), msg=_VALIDATOR.format_issues(result))
+
+    def test_long_run_rejects_bad_last_updated_format(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            long_run = Path(temp_dir) / "docs" / "long-run-state.md"
+            _write(long_run, _minimal_long_run_state(last_updated="2026/03/29"))
+
+            result = _VALIDATOR.validate_paths({"long_run_state": long_run})
+
+            self.assertFalse(result.ok())
+            self.assertIn(("last_updated", "missing '**Last updated:** YYYY-MM-DD' line"), {
+                (issue.code, issue.message) for issue in result.issues
+            })
+
+    def test_long_run_freshness_check_is_optional(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            long_run = Path(temp_dir) / "docs" / "long-run-state.md"
+            _write(long_run, _minimal_long_run_state(last_updated="2020-01-01"))
+
+            result = _VALIDATOR.validate_paths(
+                {"long_run_state": long_run},
+                today=_VALIDATOR.date(2026, 3, 29),
+                enforce_fresh_last_updated=True,
+            )
+
+            self.assertFalse(result.ok())
+            self.assertIn(("last_updated_stale", "Last updated is older than 30 days"), {
+                (issue.code, issue.message) for issue in result.issues
+            })
+
+    def test_build_or_verify_requires_iso_closeout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            build_result = Path(temp_dir) / "build-result.md"
+            _write(
+                build_result,
+                "# Build Result\n\n## Closeout (2026-3-29)\n\nBad date format.\n",
+            )
+
+            result = _VALIDATOR.validate_paths({"build_result": build_result})
+
+            self.assertFalse(result.ok())
+            self.assertIn(
+                ("closeout_subsection", "missing '## Closeout (YYYY-MM-DD)' subsection"),
+                {(issue.code, issue.message) for issue in result.issues},
+            )
+
+    def test_build_result_requires_rich_contract_sections(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            build_result = Path(temp_dir) / "build-result.md"
+            _write(
+                build_result,
+                textwrap.dedent(
+                    """\
+                    # Build Result
+
+                    ## Task
+                    Validate the slice.
+
+                    ## Status
+                    PASS
+
+                    ## Closeout (2026-03-29)
+
+                    Ready for verification.
+                    """
+                ),
+            )
+
+            result = _VALIDATOR.validate_paths({"build_result": build_result})
+
+            self.assertFalse(result.ok())
+            issue_codes = {issue.code for issue in result.issues}
+            self.assertTrue(
+                {
+                    "changes_made",
+                    "acceptance_criteria",
+                    "linting_type_check",
+                    "issues_blockers",
+                    "notes_for_verifier",
+                }.issubset(issue_codes),
+                msg=_VALIDATOR.format_issues(result),
+            )
+
+    def test_verify_result_requires_plan_builder_and_criteria_review_sections(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            verify_result = Path(temp_dir) / "verify-result.md"
+            _write(
+                verify_result,
+                textwrap.dedent(
+                    """\
+                    # Verify Result
+
+                    ## Status
+                    PASS
+
+                    ## Closeout (2026-03-29)
+
+                    Verified.
+                    """
+                ),
+            )
+
+            result = _VALIDATOR.validate_paths({"verify_result": verify_result})
+
+            self.assertFalse(result.ok())
+            issue_codes = {issue.code for issue in result.issues}
+            self.assertTrue(
+                {"plan", "builder_result", "criteria_review", "issues_found", "recommendations"}.issubset(
+                    issue_codes
+                ),
+                msg=_VALIDATOR.format_issues(result),
+            )
+
+    def test_build_result_rejects_unresolved_acceptance_criterion_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            build_result = Path(temp_dir) / "build-result.md"
+            _write(
+                build_result,
+                textwrap.dedent(
+                    """\
+                    # Build Result
+
+                    ## Task
+                    Validate the slice.
+
+                    ## Status
+                    PASS
+
+                    ## Changes Made
+                    - `docs/workflow-artifact-contract.md`: draft contract text
+
+                    ## Acceptance Criteria
+                    - [ ] Criterion 1
+
+                    ## Linting / Type-Check
+                    PASS
+
+                    ## Issues / Blockers
+                    None
+
+                    ## Notes for Verifier
+                    Inspect acceptance parsing.
+
+                    ## Closeout (2026-03-29)
+
+                    Ready for verification.
+                    """
+                ),
+            )
+
+            result = _VALIDATOR.validate_paths({"build_result": build_result})
+
+            self.assertFalse(result.ok())
+            self.assertIn(
+                ("acceptance_criteria_format", "Acceptance Criteria bullets must include PASS, FAIL, or PARTIAL"),
+                {(issue.code, issue.message) for issue in result.issues},
+            )
+
+    def test_malformed_json_fence_is_reported_deterministically(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            long_run = Path(temp_dir) / "docs" / "long-run-state.md"
+            _write(
+                long_run,
+                textwrap.dedent(
+                    """\
+                    # Long-run mission state
+
+                    **Last updated:** 2026-03-29
+
+                    ## Mission
+
+                    - **Goal:** Test JSON validation.
+                    - **execution_mode:** `long-run`
+
+                    ```json
+                    {"broken":
+                    ```
+
+                    ## Parent mission gate compliance
+
+                    - [ ] Gate entry exists.
+                    """
+                ),
+            )
+
+            result = _VALIDATOR.validate_paths({"long_run_state": long_run})
+
+            self.assertFalse(result.ok())
+            self.assertIn(
+                (
+                    "json_parse",
+                    "JSON fence starting at line 10 is invalid: Expecting value (line 1, column 11)",
+                ),
+                {(issue.code, issue.message) for issue in result.issues},
+            )
+
+    def test_phase1_verify_script_returns_nonzero_for_invalid_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_copy = Path(temp_dir) / "repo"
+            shutil.copytree(
+                REPO_ROOT,
+                repo_copy,
+                ignore=shutil.ignore_patterns(
+                    ".git",
+                    "__pycache__",
+                    "*.pyc",
+                    "node_modules",
+                    ".venv",
+                    ".uv",
+                    ".cursor/data",
+                    ".cursor/worktree",
+                    "artifacts/phase1",
+                ),
+            )
+
+            _write(repo_copy / "verify-result.md", _minimal_verify_result())
+            _write(
+                repo_copy / "docs" / "current-plan.md",
+                "# Current plan\n\n## DoR\n\n- Deliberately invalid for the script test.\n",
+            )
+
+            env = os.environ.copy()
+            env["PHASE1_VERIFY_SKIP_UNITTEST"] = "1"
+            env["PHASE1_VERIFY_SKIP_BUN"] = "1"
+            env["PHASE1_VERIFY_SKIP_CLIENT"] = "1"
+
+            completed = subprocess.run(
+                ["bash", str(repo_copy / "scripts" / "phase1-verify.sh")],
+                cwd=repo_copy,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertNotEqual(completed.returncode, 0, msg=completed.stdout + completed.stderr)
+            self.assertIn("missing '## Non-goals' subsection", completed.stdout + completed.stderr)
+
+
+class ValidateCloseoutCoherenceProfileTest(unittest.TestCase):
+    def test_missing_comparison_fails_without_adopted_marker(self) -> None:
+        closeout_path = REPO_ROOT / "scripts" / "validate_closeout_coherence.py"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            completed = subprocess.run(
+                [sys.executable, str(closeout_path), "--repo-root", str(root)],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertIn("comparison_json_missing", completed.stdout + completed.stderr)
+
+    def test_missing_comparison_skips_with_mat_sidecar_readme(self) -> None:
+        closeout_path = REPO_ROOT / "scripts" / "validate_closeout_coherence.py"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / ".mat").mkdir(parents=True)
+            (root / ".mat" / "README.md").write_text(
+                "# `.mat/` — Multi-agent workflow (MAT) sidecar\n",
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [sys.executable, str(closeout_path), "--repo-root", str(root)],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            self.assertEqual(completed.returncode, 0, msg=completed.stdout + completed.stderr)
+            self.assertIn("SKIPPED", completed.stdout)
+
+
+class WorkflowArtifactContractPathTest(unittest.TestCase):
+    def test_resolve_workflow_artifact_contract_prefers_root_docs(self) -> None:
+        ac = _load_artifact_contract_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "docs").mkdir(parents=True)
+            (root / "docs" / "workflow-artifact-contract.md").write_text("root", encoding="utf-8")
+            (root / ".mat" / "docs").mkdir(parents=True)
+            (root / ".mat" / "docs" / "workflow-artifact-contract.md").write_text(
+                "sidecar", encoding="utf-8"
+            )
+            resolved = ac.resolve_workflow_artifact_contract_doc(root)
+            self.assertIsNotNone(resolved)
+            assert resolved is not None
+            self.assertEqual(resolved.read_text(encoding="utf-8"), "root")
+
+    def test_resolve_workflow_artifact_contract_falls_back_to_mat_docs(self) -> None:
+        ac = _load_artifact_contract_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / ".mat" / "docs").mkdir(parents=True)
+            (root / ".mat" / "docs" / "workflow-artifact-contract.md").write_text(
+                "sidecar", encoding="utf-8"
+            )
+            resolved = ac.resolve_workflow_artifact_contract_doc(root)
+            self.assertIsNotNone(resolved)
+            assert resolved is not None
+            self.assertEqual(resolved.read_text(encoding="utf-8"), "sidecar")
+
+    def test_resolve_workflow_artifact_contract_none_when_missing(self) -> None:
+        ac = _load_artifact_contract_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.assertIsNone(ac.resolve_workflow_artifact_contract_doc(root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.mat/tests/test_workflow_docs.py
+++ b/.mat/tests/test_workflow_docs.py
@@ -1,0 +1,1703 @@
+import os
+import re
+import unittest
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    """Resolve repo root whether tests live in tests/ or .mat/tests/ (adopted repos)."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / ".cursor" / "hooks.json").is_file():
+            return parent
+    return here.parents[1]
+
+
+REPO_ROOT = _repo_root()
+
+
+def _resolve_path(rel_path: str) -> Path:
+    """Resolve repo-relative paths; in MAT sidecar adoptions, packaged docs live under `.mat/docs/`."""
+    primary = REPO_ROOT / rel_path
+    if primary.exists():
+        return primary
+    if rel_path.startswith("docs/"):
+        sidecar = REPO_ROOT / ".mat" / rel_path
+        if sidecar.exists():
+            return sidecar
+    return primary
+
+
+def _is_mat_sidecar_adoption_layout() -> bool:
+    """Prefer explicit `MAT_REPO_LAYOUT=adopted|source`; else detect `.mat/AGENTS.mat.md` (bootstrap sidecar)."""
+    env = os.environ.get("MAT_REPO_LAYOUT", "").strip().lower()
+    if env == "source":
+        return False
+    if env == "adopted":
+        return True
+    return (REPO_ROOT / ".mat" / "AGENTS.mat.md").is_file()
+
+
+def _read(rel_path: str) -> str:
+    return _resolve_path(rel_path).read_text(encoding="utf-8")
+
+
+def _exists(rel_path: str) -> bool:
+    return _resolve_path(rel_path).exists()
+
+
+class WorkflowCommandDocsTest(unittest.TestCase):
+    def test_plan_and_plan_onboarding_command_docs_exist_with_core_guardrails(self):
+        if not _exists("docs/planning-commands-guide.md"):
+            self.skipTest("planning commands guide not present in this trimmed fixture")
+
+        plan = _read(".cursor/commands/mat-plan.md")
+        plan_onboarding = _read(".cursor/commands/mat-plan-onboarding.md")
+        planning_guide = _read("docs/planning-commands-guide.md")
+
+        self.assertIn("# MAT Plan", plan)
+        self.assertIn("/mat-plan <task description>", plan)
+        self.assertIn("Planning only — no implementation.", plan)
+        self.assertIn("specs/<slug>.md", plan)
+        self.assertIn("solo_plan_only", plan)
+        self.assertIn("ready_for_execution_handoff", plan)
+        self.assertIn("needs_plan_onboarding", plan)
+        self.assertIn("Recommended Next Command", plan)
+        self.assertIn("Do not reuse `/mat-plan-team` execution-mode terms", plan)
+        self.assertIn("docs/capability-precedence.md", plan)
+
+        self.assertIn("# MAT Plan Onboarding", plan_onboarding)
+        self.assertIn("/mat-plan-onboarding <task description>", plan_onboarding)
+        self.assertIn(
+            "mat-plan-onboarding requires mandatory artifact package: specs/<slug>/prd.md, specs/<slug>/spec.md, specs/<slug>/tasks.json, specs/<slug>/plan-summary.md.",
+            plan_onboarding,
+        )
+        self.assertIn(
+            "Each task in tasks.json must trace to spec.md and PRD IDs; spec.md must trace back to prd.md.",
+            plan_onboarding,
+        )
+        self.assertIn(
+            "tasks.json must include a per-task execution status field so approved slices can stay aligned with real progress.",
+            plan_onboarding,
+        )
+        self.assertIn("Human approval gate required before any execution handoff.", plan_onboarding)
+        self.assertIn(
+            "Do not replace docs/current-plan.md with onboarding artifacts; use plan-summary.md to instruct projection.",
+            plan_onboarding,
+        )
+        self.assertIn("docs/capability-precedence.md", plan_onboarding)
+        self.assertIn("### Task Status Sync Contract", plan_onboarding)
+        self.assertIn("### Guided Discovery Questions", plan_onboarding)
+        self.assertIn(
+            "After drafting the onboarding package, scan `specs/<slug>/prd.md`, `specs/<slug>/spec.md`, and `specs/<slug>/plan-summary.md` for unresolved open questions before the approval gate.",
+            plan_onboarding,
+        )
+        self.assertIn(
+            "Ask unresolved questions in the chat one at a time; after each answer, update the relevant artifact(s) and keep `plan-summary.md` in sync.",
+            plan_onboarding,
+        )
+        self.assertIn(
+            "If the user declines to answer, record that explicitly as an open or deferred question in the artifacts before presenting the final approval gate.",
+            plan_onboarding,
+        )
+
+        self.assertIn("/mat-plan-onboarding", planning_guide)
+        self.assertIn("`specs/` is upstream planning truth.", planning_guide)
+        self.assertIn("Projection is human/operator-owned", planning_guide)
+        self.assertIn("Project one approved execution slice at a time into `docs/current-plan.md`.", planning_guide)
+        self.assertIn("if both `specs/<slug>.md` and `specs/<slug>/` exist, the folder package is authoritative", planning_guide)
+        self.assertIn("surface unresolved open questions in chat before approval", planning_guide.lower())
+        self.assertIn("one question at a time", planning_guide.lower())
+
+    def test_plan_onboarding_templates_and_specimen_lock_traceability_contract(self):
+        if not all(
+            _exists(path)
+            for path in (
+                "docs/templates/spec-template.md",
+                "docs/templates/tasks-schema.json",
+                "specs/mat-plan-and-plan-onboarding-v1/spec.md",
+                "specs/mat-plan-and-plan-onboarding-v1/tasks.json",
+                "specs/mat-plan-and-plan-onboarding-v1/plan-summary.md",
+                "specs/mat-plan-and-plan-onboarding-v1.md",
+            )
+        ):
+            self.skipTest("plan_onboarding templates/specimen not present in this trimmed fixture")
+
+        spec_template = _read("docs/templates/spec-template.md")
+        schema = _read("docs/templates/tasks-schema.json")
+        specimen_spec = _read("specs/mat-plan-and-plan-onboarding-v1/spec.md")
+        specimen_prd = _read("specs/mat-plan-and-plan-onboarding-v1/prd.md")
+        specimen_tasks = _read("specs/mat-plan-and-plan-onboarding-v1/tasks.json")
+        specimen_summary = _read("specs/mat-plan-and-plan-onboarding-v1/plan-summary.md")
+        planning_spec = _read("specs/mat-plan-and-plan-onboarding-v1.md")
+
+        self.assertIn("Stable spec section IDs", spec_template)
+        self.assertIn("Use `SPEC-001`, `SPEC-002`, ...", spec_template)
+        self.assertIn("Every implementation-significant design section must declare its own `SPEC-###` identifier.", spec_template)
+        self.assertIn("TASK-###", spec_template)
+
+        self.assertIn('"const": "plan_onboarding"', schema)
+        self.assertNotIn('"plan"', schema)
+        self.assertIn('"pattern": "^SPEC-[0-9]{3}$"', schema)
+        self.assertIn('"status"', schema)
+        self.assertIn('"planned"', schema)
+        self.assertIn('"in_progress"', schema)
+        self.assertIn('"done"', schema)
+        self.assertIn('"blocked"', schema)
+        self.assertIn('"deferred"', schema)
+        self.assertIn('"status_note"', schema)
+        self.assertIn('"last_updated"', schema)
+
+        self.assertIn("### `SPEC-001`", specimen_spec)
+        self.assertIn("### `SPEC-002`", specimen_spec)
+        self.assertIn("### `SPEC-003`", specimen_spec)
+        self.assertIn("### `SPEC-005`", specimen_spec)
+        self.assertIn('"spec_ids": [', specimen_tasks)
+        self.assertIn('"SPEC-001"', specimen_tasks)
+        self.assertIn('"SPEC-002"', specimen_tasks)
+        self.assertIn('"SPEC-003"', specimen_tasks)
+        self.assertIn('"SPEC-005"', specimen_tasks)
+        self.assertIn('"status": "planned"', specimen_tasks)
+        self.assertIn('"FR-005"', specimen_tasks)
+        self.assertIn('"AC-005"', specimen_tasks)
+        self.assertIn("Status: `open | resolved | deferred`", spec_template)
+
+        self.assertIn("Manual projection into `docs/current-plan.md`.", specimen_summary)
+        self.assertIn("Only after that projection step should the operator choose `/mat-plan-team` or `/mat-long-run`", specimen_summary)
+        self.assertIn("Open questions must be surfaced in chat before approval.", specimen_summary)
+        self.assertIn("Projection into `docs/current-plan.md` is human-owned and happens only after written approval.", planning_spec)
+        self.assertIn("If both exist, `specs/<slug>/` is authoritative", planning_spec)
+        self.assertIn("keep approved task execution status in sync with the active slice", planning_spec)
+        self.assertIn("approved execution slices need a deterministic `TASK-###` mapping back to `tasks.json`", specimen_prd)
+
+    def test_sprint_and_lite_command_files_exist_with_core_guardrails(self):
+        sprint = _read(".cursor/commands/mat-sprint.md")
+        lite = _read(".cursor/commands/mat-lite.md")
+        long_run = _read(".cursor/commands/mat-long-run.md")
+        subagents_spawn = _read(".cursor/commands/mat-subagents-spawn.md")
+        long_run_state = _read("docs/long-run-state.md")
+
+        self.assertIn("mission_complete", long_run_state)
+        self.assertIn("planning_gap", long_run_state)
+
+        self.assertIn("# MAT Long Run", long_run)
+        self.assertIn("/mat-long-run <mission description>", long_run)
+        self.assertIn("docs/long-run-state.md", long_run)
+        self.assertIn("post-slice mission gate", long_run)
+        self.assertIn("planning_gap", long_run)
+
+        self.assertIn("# MAT Subagents Spawn", subagents_spawn)
+        self.assertIn("/mat-subagents-spawn <task description>", subagents_spawn)
+        self.assertIn("Honesty guardrails", subagents_spawn)
+        self.assertIn("wait-before-supersede", subagents_spawn.lower())
+
+        self.assertIn("# MAT Sprint", sprint)
+        self.assertIn("/mat-sprint <task description>", sprint)
+        self.assertIn("Define a short DoR before editing", sprint)
+        self.assertIn("Preflight decision", sprint)
+        self.assertIn("builder_plus_verifier", sprint)
+        self.assertIn("Onboarding slice sync", sprint)
+        self.assertIn("Do not commit unless the user explicitly asks", sprint)
+        self.assertIn("Run at least one concrete verification step", sprint)
+
+        self.assertIn("# MAT Lite", lite)
+        self.assertIn("/mat-lite <task description>", lite)
+        self.assertIn("git diff --check", lite)
+        self.assertIn(
+            "If the task grows beyond a small bounded change, switch to `/mat-sprint`, `/mat-plan-team`, or `/mat-long-run`",
+            lite,
+        )
+        self.assertIn("Do not commit unless the user explicitly asks for it.", lite)
+
+    def test_command_and_agent_inventories_reference_new_surfaces(self):
+        if _is_mat_sidecar_adoption_layout():
+            self.skipTest(
+                "MAT sidecar adoption uses product-first root; full tables live in .mat/AGENTS.mat.md"
+            )
+        agents = _read("AGENTS.md")
+        readme = _read("README.md")
+        components = _read("docs/components.md")
+        docs_index = _read("docs/README.md") if _exists("docs/README.md") else ""
+        usage = _read("docs/usage-examples-and-cases.md") if _exists("docs/usage-examples-and-cases.md") else ""
+        best_practices = _read("docs/best-practices.md") if _exists("docs/best-practices.md") else ""
+
+        self.assertIn("| `/mat-long-run <task>` | Queued multi-slice mission with `docs/long-run-state.md` and post-slice mission gate |", agents)
+        self.assertIn("| `/mat-subagents-spawn <task>` | Decompose work and run parallel Task subagents (parent integrates results; see command doc) |", agents)
+        self.assertIn("| `/mat-sprint <task>` | Execute one bounded slice with DoR, implementation, verification, and review |", agents)
+        self.assertIn("| `/mat-lite <task>` | Run a lightweight docs/config/quality pass without the full orchestration flow |", agents)
+        self.assertIn("| `/mat-plan <task>` | Lightweight solo planning — writes one file: `specs/<slug>.md` |", agents)
+        self.assertIn(
+            "| `/mat-plan-onboarding <task>` | Heavyweight planning-only onboarding — writes the four-file package under `specs/<slug>/` |",
+            agents,
+        )
+        self.assertIn("| `/mat-wt-check` | Run worktree health and collision checks |", agents)
+        self.assertIn("| `/mat-doctor` | Run local diagnostics for workflow readiness |", agents)
+        self.assertIn("internal/reference-oriented", agents)
+        self.assertIn("not a public packaging target by default", agents)
+
+        self.assertIn("| `/mat-long-run` | Queued multi-slice mission (`docs/long-run-state.md`, mission gate) |", readme)
+        self.assertIn("| `/mat-subagents-spawn` | Parallel Task subagent fan-out with parent integration (see `.cursor/commands/mat-subagents-spawn.md`) |", readme)
+        self.assertIn("| `/mat-sprint` | Run one bounded slice end-to-end |", readme)
+        self.assertIn("| `/mat-lite` | Run a lightweight docs/config/quality pass |", readme)
+        self.assertIn("| `/mat-plan` | Lightweight solo planning — writes one file: `specs/<slug>.md` |", readme)
+        self.assertIn(
+            "| `/mat-plan-onboarding` | Heavyweight planning-only onboarding — writes the four-file package under `specs/<slug>/` |",
+            readme,
+        )
+        self.assertIn("| `/mat-wt-check` | Run worktree health checks |", readme)
+        self.assertIn("| `/mat-doctor` | Run operator diagnostics |", readme)
+        self.assertIn("| `test-writer` | Adds focused regression coverage |", readme)
+        self.assertIn("| `style-reviewer` | Aligns docs/inventories and removes overclaims |", readme)
+        self.assertIn("/mat-plan-onboarding", readme)
+        self.assertIn("internal/reference-oriented workflow repo for the maintainer team", readme)
+        self.assertIn("not a public packaging target by default", readme)
+
+        self.assertIn(".cursor/commands/mat-plan.md", components)
+        self.assertIn(".cursor/commands/mat-plan-onboarding.md", components)
+        self.assertIn("docs/planning-commands-guide.md", components)
+        self.assertIn("`../.cursor/commands/mat-long-run.md`", components)
+        self.assertIn("`../.cursor/commands/mat-subagents-spawn.md`", components)
+        self.assertIn("`../.cursor/commands/mat-sprint.md`", components)
+        self.assertIn("`../.cursor/commands/mat-lite.md`", components)
+        self.assertIn("`../.cursor/agents/test-writer.md`", components)
+        self.assertIn("`../.cursor/agents/style-reviewer.md`", components)
+        self.assertIn("internal/reference-oriented", components)
+
+        if docs_index:
+            self.assertIn("[planning-commands-guide.md](planning-commands-guide.md)", docs_index)
+            self.assertIn("[capability-precedence.md](capability-precedence.md)", docs_index)
+        if usage:
+            self.assertIn("/mat-plan-onboarding", usage)
+            self.assertIn("/mat-plan", usage)
+        if best_practices:
+            self.assertIn("/mat-plan-onboarding", best_practices)
+            self.assertIn("planning truth in `specs/`", best_practices)
+
+    def test_capability_precedence_policy_doc_locks_project_first_routing(self):
+        if not _exists("docs/capability-precedence.md"):
+            self.skipTest("capability-precedence doc not present in this trimmed fixture")
+        cap = _read("docs/capability-precedence.md")
+        self.assertIn("# Project-first capability routing (MAT v1)", cap)
+        self.assertIn("routing and precedence policy", cap)
+        self.assertIn("## Relationship to Cursor", cap)
+        self.assertIn("Team Rules", cap)
+        self.assertIn("## Precedence (highest first)", cap)
+        self.assertIn("## Capability discovery", cap)
+        self.assertIn("## Conflict rule", cap)
+        self.assertIn("## Authoritative vs advisory", cap)
+        self.assertIn("project-local", cap.lower())
+        self.assertIn(".mat/", cap)
+        self.assertIn("Plugin-provided", cap)
+        self.assertIn("Global / user-level", cap)
+        self.assertIn("docs/current-plan.md", cap)
+        self.assertIn("artifacts/mao/gate.json", cap)
+        readme = _read("README.md")
+        self.assertIn("docs/capability-precedence.md", readme)
+        maintainer = _read("docs/MAINTAINER.md")
+        self.assertIn("capability-precedence.md", maintainer)
+        components = _read("docs/components.md")
+        self.assertIn("capability-precedence.md", components)
+        if not _is_mat_sidecar_adoption_layout():
+            agents = _read("AGENTS.md")
+            self.assertIn("docs/capability-precedence.md", agents)
+
+    def test_model_routing_policy_doc_locks_conservative_adapter_agnostic_policy(self):
+        required = (
+            "docs/model-routing-policy.md",
+            "docs/context-budget-policy.md",
+            "docs/schemas/mat-routing-advisory.example.json",
+            "README.md",
+            "AGENTS.md",
+            "docs/README.md",
+            "docs/components.md",
+            "docs/best-practices.md",
+            "docs/MAINTAINER.md",
+            "docs/capability-precedence.md",
+            ".cursor/agents/parent-orchestrator.md",
+            ".cursor/commands/mat-plan-team.md",
+            ".cursor/agents/builder.md",
+            ".cursor/agents/verifier.md",
+            ".cursor/commands/mat-sprint.md",
+            ".cursor/commands/mat-long-run.md",
+        )
+        if not all(_exists(path) for path in required):
+            self.skipTest("model routing policy docs not present in this trimmed fixture")
+
+        policy = _read("docs/model-routing-policy.md")
+        context_budget = _read("docs/context-budget-policy.md")
+        advisory_example = _read("docs/schemas/mat-routing-advisory.example.json")
+        readme = _read("README.md")
+        agents = _read("AGENTS.md")
+        docs_index = _read("docs/README.md")
+        components = _read("docs/components.md")
+        best_practices = _read("docs/best-practices.md")
+        maintainer = _read("docs/MAINTAINER.md")
+        cap = _read("docs/capability-precedence.md")
+        orchestrator = _read(".cursor/agents/parent-orchestrator.md")
+        plan_w_team = _read(".cursor/commands/mat-plan-team.md")
+        builder = _read(".cursor/agents/builder.md")
+        verifier = _read(".cursor/agents/verifier.md")
+        sprint = _read(".cursor/commands/mat-sprint.md")
+        long_run = _read(".cursor/commands/mat-long-run.md")
+
+        self.assertIn("# MAT routing policy v1", policy)
+        self.assertIn("cheap", policy)
+        self.assertIn("standard", policy)
+        self.assertIn("strong", policy)
+        self.assertIn("multimodal", policy)
+        self.assertIn("adapter-agnostic", policy)
+        self.assertIn("does not depend on `agent-model-router`", policy)
+        self.assertIn("does not describe undocumented Cursor alias-style frontmatter behavior", policy)
+        self.assertIn("Telemetry in this slice is advisory only.", policy)
+        self.assertIn("provider", policy)
+        self.assertIn("routing_reason", policy)
+        self.assertIn("context_pressure", policy)
+        self.assertIn("session_id", policy)
+        self.assertIn("timestamp", policy)
+        self.assertIn("The `signal_class` stays `advisory`", policy)
+        self.assertIn("artifacts/mao/routing-advisory.jsonl", policy)
+        self.assertIn("routing_rollup_<session_id>.json", policy)
+        self.assertIn("scripts/analyze_routing_advisory.py", policy)
+        self.assertIn("deferred adapter boundary", policy)
+        self.assertIn("Where MAT surfaces routing telemetry", policy)
+        self.assertIn("Authoritative vs advisory (routing context)", policy)
+        self.assertIn("schemas/mat-routing-advisory.example.json", policy)
+        self.assertIn("docs/context-budget-policy.md", policy)
+        self.assertIn("source_hook", policy)
+        self.assertIn("session_id", policy)
+        self.assertIn("timestamp", policy)
+        self.assertIn("suggested_tier", policy)
+        self.assertIn("recommended_escalation", policy)
+        self.assertIn("boundary_signals", policy)
+        self.assertIn("70 percent", policy)
+        self.assertIn("6000 characters", policy)
+        self.assertIn("25", policy)
+
+        self.assertIn("# MAT context budget policy v1", context_budget)
+        self.assertIn("bounded context", context_budget.lower())
+        self.assertIn("artifact-first", context_budget.lower())
+        self.assertIn("Soft context-pressure signals", context_budget)
+        self.assertIn("Pre-compact / large prompt payloads", context_budget)
+        self.assertIn("boundary_signals", context_budget)
+        self.assertIn("70 / 6000 / 25", context_budget)
+        self.assertIn("Parent orchestrator", context_budget)
+        self.assertIn("README.md", context_budget)
+        self.assertIn("ROADMAP.md", context_budget)
+        self.assertIn("AGENTS.md", context_budget)
+        self.assertIn("prompt_lint_<session_id>.log", context_budget)
+        self.assertIn("CURSOR_MAT_SESSION_BUDGET_USD", context_budget)
+        self.assertIn("never block execution", context_budget)
+
+        self.assertIn("mat_routing_advisory_version", advisory_example)
+        self.assertIn('"source_hook"', advisory_example)
+        self.assertIn('"timestamp"', advisory_example)
+        self.assertIn('"session_id"', advisory_example)
+        self.assertIn('"provider"', advisory_example)
+        self.assertIn('"routing_tier"', advisory_example)
+        self.assertIn('"routing_reason"', advisory_example)
+        self.assertIn('"suggested_tier"', advisory_example)
+        self.assertIn('"recommended_escalation"', advisory_example)
+        self.assertIn("budget_note", advisory_example)
+        self.assertIn('"context_pressure"', advisory_example)
+        self.assertIn('"payload_size_chars"', advisory_example)
+        self.assertIn('"payload_size_bytes"', advisory_example)
+        self.assertIn('"retry_count"', advisory_example)
+        self.assertIn('"boundary_signals"', advisory_example)
+        self.assertIn('"input_tokens"', advisory_example)
+        self.assertIn("signal_class", advisory_example)
+        self.assertIn("advisory", advisory_example)
+        self.assertIn("non_authoritative", advisory_example)
+
+        self.assertIn("Model routing policy", readme)
+        self.assertIn("cheap` / `standard` / `strong` policy", readme)
+        self.assertIn("routing rollups", readme)
+        self.assertIn("prompt lint warnings", readme)
+        self.assertIn("session budget notes", readme)
+        self.assertIn("representative baselines", readme)
+        self.assertIn("docs/model-routing-policy.md", readme)
+        self.assertIn("Context budget", readme)
+        self.assertIn("docs/context-budget-policy.md", readme)
+
+        self.assertIn("docs/model-routing-policy.md", agents)
+        self.assertIn("adapter-agnostic", agents)
+        self.assertIn("routing_rollup_<session_id>.json", agents)
+        self.assertIn("scripts/analyze_routing_advisory.py", agents)
+        self.assertIn("prompt lint warnings", agents)
+        self.assertIn("session budget notes", agents)
+        self.assertIn("docs/context-budget-policy.md", agents)
+
+        self.assertIn("model-routing-policy.md", docs_index)
+        self.assertIn("Conservative MAT routing tiers", docs_index)
+        self.assertIn("routing_advisory.md", docs_index)
+        self.assertIn("session rollups", docs_index)
+        self.assertIn("context-budget-policy.md", docs_index)
+        self.assertIn("operational baseline", docs_index)
+
+        self.assertIn("Routing policy", components)
+        self.assertIn("docs/model-routing-policy.md", components)
+        self.assertIn("routing_advisory.md", components)
+        self.assertIn("session rollups", components)
+        self.assertIn("context-budget-policy.md", components)
+        self.assertIn("routing advisories", components)
+
+        self.assertIn("model-routing-policy.md", best_practices)
+        self.assertIn("routing telemetry, rollups, and budget notes are advisory, not workflow truth", best_practices)
+        self.assertIn("analyze_routing_advisory.py", best_practices)
+        self.assertIn("missing `build-result.md` or `verify-result.md`", best_practices)
+        self.assertIn("context-budget-policy.md", best_practices)
+        self.assertIn("routing-advisory.jsonl", best_practices)
+        self.assertIn("routing_rollup_<session_id>.json", best_practices)
+        self.assertIn("prompt lint warnings", best_practices)
+        self.assertIn("session budget notes", best_practices)
+        self.assertIn("context_pressure_rate", best_practices)
+        self.assertIn("closeout validation", best_practices)
+
+        self.assertIn("docs/model-routing-policy.md", maintainer)
+        self.assertIn("adapter boundary optional", maintainer)
+        self.assertIn("routing_rollup_<session_id>.json", maintainer)
+        self.assertIn("analyze_routing_advisory.py", maintainer)
+        self.assertIn("generate_fixture_from_session.sh", maintainer)
+        self.assertIn("context-budget-policy.md", maintainer)
+        self.assertIn("CURSOR_MAT_ROUTING_ADVISORY_JSONL", maintainer)
+        self.assertIn("CURSOR_MAT_ROUTING_ADVISORY_ROLLUP", maintainer)
+        self.assertIn("CURSOR_MAT_SESSION_BUDGET_USD", maintainer)
+        self.assertIn("prompt warnings", maintainer)
+
+        self.assertIn("model-routing-policy.md", cap)
+        self.assertIn("conservative MAT routing tiers and advisory budget policy", cap)
+        self.assertIn("context-budget-policy.md", cap)
+
+        self.assertIn("docs/model-routing-policy.md", orchestrator)
+        self.assertIn("do not invent Cursor alias behavior as a MAT contract", orchestrator)
+        self.assertIn("docs/context-budget-policy.md", orchestrator)
+
+        self.assertIn("docs/model-routing-policy.md", plan_w_team)
+        self.assertIn("avoid encoding undocumented Cursor alias-style frontmatter behavior as MAT core policy", plan_w_team)
+        self.assertIn("docs/context-budget-policy.md", plan_w_team)
+
+        self.assertIn("docs/context-budget-policy.md", builder)
+        self.assertIn("docs/context-budget-policy.md", verifier)
+        self.assertIn("docs/context-budget-policy.md", sprint)
+        self.assertIn("docs/context-budget-policy.md", long_run)
+
+    def test_artifact_contract_doc_and_prompt_examples_stay_aligned(self):
+        if not _exists("docs/workflow-artifact-contract.md"):
+            self.skipTest("artifact contract doc not present in this trimmed fixture")
+        contract = _read("docs/workflow-artifact-contract.md")
+        builder = _read(".cursor/agents/builder.md")
+        build = _read(".cursor/commands/mat-build.md")
+        verifier = _read(".cursor/agents/verifier.md")
+        review = _read(".cursor/commands/mat-review.md")
+        orchestrator = _read(".cursor/agents/parent-orchestrator.md")
+        plan_w_team = _read(".cursor/commands/mat-plan-team.md")
+        long_run = _read(".cursor/commands/mat-long-run.md")
+
+        self.assertIn("# Workflow Artifact Contract", contract)
+        self.assertIn("## Build Result Contract", contract)
+        self.assertIn("## Verify Result Contract", contract)
+        self.assertIn("## Closeout (YYYY-MM-DD)", contract)
+
+        for text in (builder, build):
+            self.assertIn("## Closeout (YYYY-MM-DD)", text)
+            self.assertIn("## Notes for Verifier", text)
+            self.assertIn("docs/workflow-artifact-contract.md", text)
+
+        for text in (verifier, review):
+            self.assertIn("## Criteria Review", text)
+            self.assertIn("## Closeout (YYYY-MM-DD)", text)
+            self.assertIn("docs/workflow-artifact-contract.md", text)
+
+        for text in (orchestrator, plan_w_team, long_run):
+            self.assertIn("docs/workflow-artifact-contract.md", text)
+
+        self.assertIn("docs/capability-precedence.md", orchestrator)
+        self.assertIn("docs/capability-precedence.md", plan_w_team)
+
+    def test_execution_closeout_contract_and_prompt_defaults_are_explicit(self):
+        required = (
+            "AGENTS.md",
+            "README.md",
+            "docs/best-practices.md",
+            "docs/orchestration-workflow.md",
+            "docs/mat-plan-team-spec.md",
+            "docs/update-mat/role-prompt-templates.md",
+            ".cursor/commands/mat-plan-team.md",
+            ".cursor/commands/mat-long-run.md",
+            ".cursor/commands/mat-plan-onboarding.md",
+            ".cursor/commands/mat-build.md",
+            ".cursor/commands/mat-review.md",
+            ".cursor/agents/parent-orchestrator.md",
+        )
+        if not all(_exists(path) for path in required):
+            self.skipTest("execution closeout contract docs not present in this trimmed fixture")
+
+        agents = _read("AGENTS.md")
+        best_practices = _read("docs/best-practices.md")
+        workflow = _read("docs/orchestration-workflow.md")
+        spec = _read("docs/mat-plan-team-spec.md")
+        plan_w_team = _read(".cursor/commands/mat-plan-team.md")
+        long_run = _read(".cursor/commands/mat-long-run.md")
+        plan_onboarding = _read(".cursor/commands/mat-plan-onboarding.md")
+        build = _read(".cursor/commands/mat-build.md")
+        review = _read(".cursor/commands/mat-review.md")
+        parent = _read(".cursor/agents/parent-orchestrator.md")
+        readme = _read("README.md")
+        changelog = _read("CHANGELOG.md")
+        roadmap = _read("ROADMAP.md")
+        update_mat = _read("docs/update-mat/role-prompt-templates.md")
+
+        self.assertIn("fenced `txt` blocks", agents)
+        self.assertIn("fenced `txt` blocks", best_practices)
+        self.assertIn("fenced `txt` blocks", update_mat)
+        self.assertIn("execution-closeout-contract", plan_w_team)
+        self.assertIn("execution-closeout-contract", long_run)
+        self.assertIn("execution-closeout-contract", plan_onboarding)
+        self.assertIn("execution-closeout-contract", build)
+        self.assertIn("execution-closeout-contract", review)
+        self.assertIn("execution-closeout-contract", readme)
+        self.assertIn("execution-closeout-contract", spec)
+        self.assertIn("## Execution closeout contract", workflow)
+        self.assertIn("README.md", workflow)
+        self.assertIn("AGENTS.md", workflow)
+        self.assertIn("CHANGELOG.md", workflow)
+        self.assertIn("ROADMAP.md", workflow)
+        self.assertIn("Commit the final state", workflow)
+        self.assertIn("Push when the handoff is meant to leave the branch shared remotely", workflow)
+        self.assertIn("Confirm the working tree is clean", workflow)
+        self.assertIn("validate_closeout_coherence.py", workflow)
+        self.assertIn("git status --short", workflow)
+        self.assertIn("CHANGELOG.md", readme)
+        self.assertIn("ROADMAP.md", readme)
+        self.assertIn("CHANGELOG.md", agents)
+        self.assertIn("ROADMAP.md", agents)
+        self.assertIn("CHANGELOG.md", best_practices)
+        self.assertIn("ROADMAP.md", best_practices)
+        self.assertIn("Current Focus", roadmap)
+        self.assertIn("Maintenance Notes", roadmap)
+        self.assertIn("no claim of live authoritative todo parity", roadmap)
+        self.assertIn("Top-level docs and maintenance guidance", changelog)
+        self.assertIn("normal startup", parent.lower())
+        self.assertIn("active progress", parent.lower())
+        self.assertIn("unclear state", parent.lower())
+        self.assertIn("true stall/failure", parent.lower())
+
+    def test_phase2_proof_tiers_and_closeout_gate_wording_stay_aligned(self):
+        if not _exists("docs/mat-plan-team-spec.md") or not _exists("artifacts/agent-traces/README.md"):
+            self.skipTest("phase2 proof-tier docs not present in this trimmed fixture")
+        spec = _read("docs/mat-plan-team-spec.md")
+        traces = _read("artifacts/agent-traces/README.md")
+        orchestrator = _read(".cursor/agents/parent-orchestrator.md")
+        maintainer = _read("docs/MAINTAINER.md")
+        readme = _read("README.md")
+
+        for text in (spec, traces):
+            self.assertIn("policy-required delegation", text)
+            self.assertIn("spawn requested", text)
+            self.assertIn("generic runtime spawn observed", text)
+            self.assertIn("correlated role attribution", text)
+            self.assertIn("typed role proved", text)
+
+        for text in (orchestrator, maintainer, readme):
+            self.assertIn("final closeout freshness gate", text.lower())
+            self.assertIn("validate_closeout_coherence.py", text)
+
+    def test_phase3_verification_ladder_and_escalation_wording_stay_aligned(self):
+        required = (
+            "docs/pilot/pilot-new/README.md",
+            "docs/pilot/pilot-new/step-by-step.md",
+            "docs/pilot/pilot-new/success-criteria.md",
+            "docs/pilot/pilot-existing/step-by-step.md",
+            "docs/best-practices.md",
+            ".cursor/commands/mat-sprint.md",
+            ".cursor/commands/mat-plan-team.md",
+            ".cursor/agents/parent-orchestrator.md",
+            ".cursor/agents/builder.md",
+            ".cursor/agents/verifier.md",
+        )
+        if not all(_exists(path) for path in required):
+            self.skipTest("phase3 ladder/escalation docs not present in this trimmed fixture")
+
+        ladder = _read("docs/local-app-verification-ladder.md")
+        pilot_new_readme = _read("docs/pilot/pilot-new/README.md")
+        pilot_new_steps = _read("docs/pilot/pilot-new/step-by-step.md")
+        pilot_new_success = _read("docs/pilot/pilot-new/success-criteria.md")
+        pilot_existing_steps = _read("docs/pilot/pilot-existing/step-by-step.md")
+        best_practices = _read("docs/best-practices.md")
+        sprint = _read(".cursor/commands/mat-sprint.md")
+        plan_w_team = _read(".cursor/commands/mat-plan-team.md")
+        orchestrator = _read(".cursor/agents/parent-orchestrator.md")
+        builder = _read(".cursor/agents/builder.md")
+        verifier = _read(".cursor/agents/verifier.md")
+
+        self.assertIn("manual/staging", ladder.lower())
+        self.assertIn("deterministic local automation", ladder.lower())
+        self.assertIn("browser-use", ladder.lower())
+        self.assertIn("playwright", ladder.lower())
+        self.assertIn("default baseline", ladder.lower())
+        self.assertIn("unless deterministic local automation already exists", ladder.lower())
+
+        for text in (pilot_new_readme, pilot_new_steps, pilot_new_success, pilot_existing_steps):
+            self.assertIn("local-app-verification-ladder.md", text)
+            self.assertIn("manual/staging", text.lower())
+            self.assertIn("deterministic local automation", text.lower())
+
+        for text in (best_practices, sprint, plan_w_team, orchestrator, builder, verifier):
+            self.assertIn("targeted regression", text.lower())
+            self.assertIn("explicit documented exception", text.lower())
+
+        for text in (builder, verifier):
+            self.assertIn("hooks", text.lower())
+            self.assertIn("validators", text.lower())
+            self.assertIn("artifact parsing", text.lower())
+            self.assertIn("mao transitions", text.lower())
+
+    def test_phase4_memory_hygiene_and_artifact_taxonomy_stay_aligned(self):
+        required = (
+            "AGENTS.md",
+            "README.md",
+            "docs/README.md",
+            "docs/MAINTAINER.md",
+            ".gitignore",
+            "artifacts/agent-traces/README.md",
+        )
+        if not all(_exists(path) for path in required):
+            self.skipTest("phase4 taxonomy docs not present in this trimmed fixture")
+
+        agents = _read("AGENTS.md")
+        readme = _read("README.md")
+        docs_index = _read("docs/README.md")
+        maintainer = _read("docs/MAINTAINER.md")
+        gitignore = _read(".gitignore")
+        traces = _read("artifacts/agent-traces/README.md")
+
+        self.assertIn("## Durable Repo Facts", agents)
+        self.assertIn("## Workspace-Local Operational Facts", agents)
+        self.assertIn("## Dated Evidence References", agents)
+        self.assertIn("docs/todo-orchestration-pilot.md", agents)
+        self.assertIn("docs/pilot-report.md", agents)
+
+        for text in (readme, docs_index, maintainer):
+            self.assertIn("canonical tracked handoffs", text.lower())
+            self.assertIn("tracked distilled evidence", text.lower())
+            self.assertIn("local mutable runtime exhaust", text.lower())
+            self.assertIn("raw/sensitive captures", text.lower())
+
+        self.assertIn("`docs/current-plan.md`", readme)
+        self.assertIn("`docs/current-plan.md`", maintainer)
+        self.assertNotIn("docs/current-plan.md", gitignore)
+        self.assertIn("artifacts/phase1/phase1-verify.log", gitignore)
+        self.assertIn("artifacts/agent-traces/*/", gitignore)
+        self.assertIn("comparison.json", traces)
+        self.assertIn("comparison.md", traces)
+        self.assertIn("local run directories", traces.lower())
+
+    def test_phase5_phase1_verify_log_is_only_local_rerun_evidence(self):
+        required = (
+            "artifacts/phase1/README.md",
+            "artifacts/phase1/phase1-verification-report.md",
+            "docs/pilot-report.md",
+            "docs/phase1-validation-report.md",
+            "docs/troubleshooting.md",
+        )
+        if not all(_exists(path) for path in required):
+            self.skipTest("phase5 phase1 log docs not present in this trimmed fixture")
+
+        phase1_readme = _read("artifacts/phase1/README.md")
+        phase1_report = _read("artifacts/phase1/phase1-verification-report.md")
+        pilot_report = _read("docs/pilot-report.md")
+        validation_report = _read("docs/phase1-validation-report.md")
+        troubleshooting = _read("docs/troubleshooting.md")
+
+        self.assertIn("local mutable runtime exhaust", phase1_readme.lower())
+        self.assertIn("latest local rerun log", phase1_report.lower())
+        self.assertIn("local rerun log", pilot_report.lower())
+        self.assertIn("local rerun log", validation_report.lower())
+        self.assertIn("latest local rerun log", troubleshooting.lower())
+        self.assertNotIn("latest sign-off run is `artifacts/phase1/phase1-verify.log`", validation_report)
+        self.assertNotIn("latest sign-off run is `artifacts/phase1/phase1-verify.log`", phase1_report)
+
+    def test_phase5_green_bar_status_docs_stay_honest(self):
+        required = ("README.md", "ROADMAP.md")
+        if not all(_exists(path) for path in required):
+            self.skipTest("phase5 status docs not present in this trimmed fixture")
+
+        readme = _read("README.md")
+        roadmap = _read("ROADMAP.md")
+
+        self.assertIn("Phase 5 completed the rollout and green-bar validation pass", readme)
+        self.assertIn("workflow is green under the scoped hardening criteria", readme)
+        self.assertIn("Phase 5 — Shipped", roadmap)
+        self.assertIn("Green bar — Met", roadmap)
+        self.assertIn("blocked runtime-limitations stay explicit", roadmap.lower())
+
+    def test_continual_learning_hygiene_docs_are_linked(self):
+        required = (
+            ".cursor/rules/continual-learning-hygiene.mdc",
+            "docs/continual-learning-safe-handling.md",
+            "README.md",
+            "AGENTS.md",
+            "docs/MAINTAINER.md",
+            "docs/README.md",
+        )
+        if not all(_exists(path) for path in required):
+            self.skipTest("continual-learning hygiene doc set not present in this trimmed fixture")
+
+        rule = _read(".cursor/rules/continual-learning-hygiene.mdc")
+        design = _read("docs/continual-learning-safe-handling.md")
+        readme = _read("README.md")
+        agents = _read("AGENTS.md")
+        maintainer = _read("docs/MAINTAINER.md")
+        docs_index = _read("docs/README.md")
+
+        self.assertIn("intentional memory maintenance", rule)
+        self.assertIn("fresh maintenance session", rule)
+        self.assertIn("12 bullets", rule)
+        self.assertIn("queue-first memory-maintenance flow", design)
+        self.assertIn("fresh chat/session", design)
+        self.assertIn("continual-learning-safe-handling.md", readme)
+        self.assertIn("continual-learning-safe-handling.md", docs_index)
+        self.assertIn("continual-learning AGENTS edits", maintainer)
+        self.assertIn("Treat continual-learning `AGENTS.md` edits as intentional memory maintenance", agents)
+
+
+class LongRunOrchestrationContractTest(unittest.TestCase):
+    """Contract tests for docs/prompt-only long-run workflow (approved plan alignment)."""
+
+    def test_long_run_state_has_mandatory_sections_and_all_stop_reasons(self):
+        if _is_mat_sidecar_adoption_layout():
+            self.skipTest(
+                "MAT sidecar adoption may ship a minimal or legacy long-run-state; full contract is MAT-repo scope"
+            )
+        text = _read("docs/long-run-state.md")
+        for heading in (
+            "## Mission",
+            "## Scope / hard constraints / non-goals",
+            "## Slice preflight decision",
+            "## Ordered slice queue",
+            "## Active slice",
+            "## Completed slices",
+            "## Continuation policy",
+            "## Stop-reason policy",
+            "## Parent mission gate compliance",
+        ):
+            self.assertIn(heading, text, msg=f"missing section {heading}")
+        self.assertIn("do **not** enforce", text.lower())
+        self.assertIn("test_workflow_docs.py", text)
+        self.assertIn("execution_mode", text)
+        self.assertIn("inline", text)
+        self.assertIn("builder_plus_verifier", text)
+        self.assertIn("parallel_spawn", text)
+        self.assertIn("execution_rationale", text)
+        self.assertIn("source_task_id", text)
+        for reason in (
+            "mission_complete",
+            "hard_blocker",
+            "approval_needed",
+            "planning_gap",
+            "unexpected_termination",
+        ):
+            self.assertIn(reason, text, msg=f"stop reason {reason}")
+
+    def test_long_run_command_covers_plan_phase2_requirements(self):
+        cmd = _read(".cursor/commands/mat-long-run.md")
+        self.assertIn("## Purpose", cmd)
+        self.assertIn("## Preflight decision", cmd)
+        self.assertIn("## Startup workflow", cmd)
+        self.assertIn("## Required artifacts", cmd)
+        self.assertIn("## Ordered slice loop", cmd)
+        self.assertIn("## Post-slice mission gate", cmd)
+        self.assertIn("## Stop conditions", cmd)
+        self.assertIn("## Relationship to other commands", cmd)
+        self.assertIn("/mat-sprint", cmd)
+        self.assertIn("/mat-plan-team", cmd)
+        self.assertIn("TASK-###", cmd)
+        self.assertIn("tasks.json", cmd)
+        # Phase 2: initialize mission state before first builder; slice plan from queue row only
+        self.assertRegex(
+            cmd.lower(),
+            r"before.*first builder|initialize.*before.*builder",
+            msg="expected explicit initialize-before-builder dispatch",
+        )
+        self.assertIn("active", cmd.lower())
+        self.assertIn("queued slice", cmd.lower())
+        self.assertIn("execution_mode", cmd)
+        self.assertIn("builder_plus_verifier", cmd)
+        self.assertIn("parallel_spawn", cmd)
+        self.assertIn("one-line rationale", cmd)
+        self.assertNotIn("slice_execution_mode", cmd)
+        # Honesty: no autonomous overclaim
+        self.assertIn("autonomous", cmd.lower())
+        self.assertIn("Parent mission gate compliance", cmd)
+
+    def test_parent_orchestrator_has_mission_gate_and_slice_vs_mission_rules(self):
+        po = _read(".cursor/agents/parent-orchestrator.md")
+        self.assertIn("## Task tool mandate (policy)", po)
+        self.assertIn("## Long-run missions", po)
+        self.assertIn("### Step 0 — Preflight decision", po)
+        self.assertIn("### Step 5b — Post-slice mission gate", po)
+        self.assertIn("Step 1c — Onboarding task status sync", po)
+        self.assertIn("queued slices remain", po)
+        self.assertIn("planning_gap", po)
+        self.assertIn("not mission complete", po.lower())
+        self.assertIn("multi-row backlog", po.lower())
+        self.assertIn("wait-before-supersede", po)
+        self.assertIn("`build-result.md` by itself is not idle evidence", po)
+        self.assertIn("`verify-result.md` by itself is not stall evidence", po)
+        self.assertIn("advisory progress helper", po)
+        self.assertIn("operator-owned evidence or posture decisions", po)
+        self.assertNotIn("slice_execution_mode", po)
+
+    def test_plan_w_team_clarifies_not_default_long_run_without_contract(self):
+        pwt = _read(".cursor/commands/mat-plan-team.md")
+        self.assertIn("Task", pwt)
+        self.assertIn("## Long-run vs single cycle", pwt)
+        self.assertIn("## Preflight decision", pwt)
+        self.assertIn("/mat-long-run", pwt)
+        self.assertIn("docs/long-run-state.md", pwt)
+        self.assertIn("post-slice mission gate", pwt)
+        self.assertIn("Step 1c", pwt)
+        self.assertIn("builder_plus_verifier", pwt)
+        self.assertIn("inline", pwt)
+        self.assertIn("delegated multi-agent orchestration command", pwt)
+        self.assertIn("default and intended mode", pwt)
+        self.assertIn("narrow exception", pwt)
+        self.assertIn("not an equal default path", pwt)
+        self.assertIn("advisory progress helper", pwt)
+        self.assertIn("Missing `build-result.md` alone is not a reason", pwt)
+
+    def test_readme_explains_command_triplet(self):
+        if _is_mat_sidecar_adoption_layout():
+            self.skipTest("MAT sidecar adoption uses a product-first README stub at repo root")
+        readme = _read("README.md")
+        self.assertIn("**Choosing a command:**", readme)
+        self.assertIn("/mat-sprint", readme)
+        self.assertIn("/mat-plan-team", readme)
+        self.assertIn("/mat-long-run", readme)
+        self.assertIn("matching `tasks.json` status synchronized with the active slice", readme)
+        self.assertIn("post-slice mission gate", readme)
+        self.assertIn("Preflight decision", readme)
+        self.assertIn("delegated builder -> verifier orchestration cycle by default", readme)
+
+    def test_docs_readme_toc_links_long_run_state(self):
+        doc_index = _read("docs/README.md")
+        self.assertRegex(doc_index, re.compile(r"^Last updated: \d{4}-\d{2}-\d{2}$", re.MULTILINE))
+        self.assertIn("[long-run-state.md](long-run-state.md)", doc_index)
+        self.assertIn("../.cursor/commands/mat-long-run.md", doc_index)
+        self.assertIn("parent-orchestrator", doc_index)
+        self.assertIn("execution_mode", doc_index)
+        self.assertIn("execution_rationale", doc_index)
+        self.assertNotIn("slice_execution_mode", doc_index)
+
+    def test_phase4_reassessment_checklist_contract(self):
+        text = _read("docs/phase4-roadmap-reassessment-checklist.md")
+        self.assertIn("mao-advisory-go-criteria.md", text)
+        self.assertIn("decision-record.md", text)
+        self.assertIn("ROADMAP.md", text)
+        self.assertIn("G4", text)
+        self.assertIn("prepare evidence", text)
+        self.assertIn("operator-owned", text)
+
+
+class StopValidatorHonestyDocsTest(unittest.TestCase):
+    """P0-2: wired `stop_validator.py` vs optional `validators/` utilities; no repo-default overclaim."""
+
+    def test_agents_and_components_document_shipped_stop_vs_optional_validators(self):
+        if not _exists("docs/components.md"):
+            self.skipTest("components.md not present in this trimmed fixture")
+        agents = _read("AGENTS.md")
+        if "# AGENTS.md — Cursor-First Agentic Workflow Guide" not in agents:
+            self.skipTest(
+                "packaged/adoption AGENTS.md stub at resolved repo root — full stop-validator honesty lives in MAT repo AGENTS.md"
+            )
+        components = _read("docs/components.md")
+        for text in (agents, components):
+            self.assertIn("stop_validator.py", text)
+            self.assertIn("send_event.py", text)
+            self.assertIn("validators/", text)
+        self.assertIn("additional commands on the shipped `stop` array", agents)
+        self.assertIn("Phase 1", agents)
+        self.assertIn("permissive", agents.lower())
+        self.assertNotIn("blocks stop if required content is missing", agents.lower())
+        self.assertNotIn("blocks stop if expected output file was not created", agents.lower())
+        self.assertIn("Not wired on shipped `stop`", components)
+        self.assertIn("Phase 1 permissive", components)
+        self.assertNotIn("Blocks completion if required text is missing", components)
+        self.assertNotIn("Blocks completion if expected files are absent", components)
+
+    def test_usage_guide_events_and_features_retain_stop_honesty_boundaries(self):
+        """P0-2 follow-up: usage guide + other honesty surfaces stay aligned with shipped `stop`."""
+        if not _exists("docs/MULTI_AGENT_USAGE_GUIDE.md"):
+            self.skipTest("MULTI_AGENT_USAGE_GUIDE.md not present in this trimmed fixture")
+        if not _exists("docs/events-and-visualization.md") or not _exists("docs/features-demonstrated.md"):
+            self.skipTest("honesty companion docs not present in this trimmed fixture")
+        agents = _read("AGENTS.md")
+        if "# AGENTS.md — Cursor-First Agentic Workflow Guide" not in agents:
+            self.skipTest(
+                "packaged/adoption AGENTS.md stub at resolved repo root — full stop-validator honesty tests skipped"
+            )
+        guide = _read("docs/MULTI_AGENT_USAGE_GUIDE.md")
+        events = _read("docs/events-and-visualization.md")
+        features = _read("docs/features-demonstrated.md")
+        g = guide.lower()
+        self.assertNotIn("your exit-code-2 validators", g)
+        self.assertNotIn("can block agent until acceptance criteria met", g)
+        self.assertIn("Shipped `stop` in this repository:", guide)
+        self.assertIn("Phase 1 permissive", guide)
+        self.assertIn("Optional customization", guide)
+        self.assertIn("stop_validator.py", guide)
+        self.assertIn("send_event.py", guide)
+        self.assertIn("`failClosed` false", guide)
+        self.assertIn("honesty boundary:", events)
+        self.assertIn("only validator wired on `stop`", events)
+        self.assertIn("not on shipped `stop`", features)
+
+
+class ObservabilitySecurityHonestyDocsTest(unittest.TestCase):
+    """P0-3: observability payload preview caps, tool_output honesty, no complete-record overclaim."""
+
+    def test_events_and_visualization_documents_preview_caps_and_tool_output(self):
+        if not _exists("docs/events-and-visualization.md"):
+            self.skipTest("events-and-visualization.md not present in this trimmed fixture")
+        events = _read("docs/events-and-visualization.md")
+        self.assertIn("Payload preview and secret-handling notes", events)
+        self.assertIn("tool_output", events)
+        self.assertIn("800", events)
+        self.assertIn("65536", events)
+        self.assertIn("hook-schema.ts", events)
+        self.assertIn("truncated", events.lower())
+        self.assertIn("not a redacted audit log", events.lower())
+        self.assertIn("do not assume payload previews are complete", events.lower())
+        self.assertNotIn("complete record of all tool output", events.lower())
+        self.assertNotIn("dashboard previews are complete records", events.lower())
+
+    def test_maintainer_documents_observability_data_handling(self):
+        if not _exists("docs/MAINTAINER.md"):
+            self.skipTest("MAINTAINER.md not present in this trimmed fixture")
+        maintainer = _read("docs/MAINTAINER.md")
+        self.assertIn("Observability data handling", maintainer)
+        self.assertIn("tool_output", maintainer)
+        self.assertIn("truncated", maintainer.lower())
+        self.assertIn("OBSERVABILITY_API_TOKEN", maintainer)
+        self.assertIn("sensitive local runtime exhaust", maintainer.lower())
+        self.assertIn("should not be treated as the full record", maintainer.lower())
+        self.assertNotIn("dashboard previews are complete records", maintainer.lower())
+
+
+class ObservabilityRetentionPolicyDocsTest(unittest.TestCase):
+    """P2: observability retention policy doc, honesty strings, and cross-links."""
+
+    def test_retention_policy_exists_with_honesty_strings(self):
+        rel = "docs/observability-retention-policy.md"
+        if not _exists(rel):
+            self.skipTest("observability-retention-policy.md not present in this trimmed fixture")
+        policy = _read(rel)
+        self.assertIn("Last updated: 2026-06-22", policy)
+        self.assertIn("advisory", policy.lower())
+        self.assertIn("800", policy)
+        self.assertIn("65536", policy)
+        self.assertIn("OBSERVABILITY_DB_PATH", policy)
+        self.assertIn("artifacts/phase1", policy)
+        self.assertIn("artifacts/mat-runtime", policy)
+        self.assertIn("hook_events", policy)
+        self.assertIn("hook-schema.ts", policy)
+        self.assertIn("truncat", policy.lower())
+        self.assertIn("full", policy.lower())
+        self.assertIn("sqlite", policy.lower())
+        for phrase in (
+            "no automatic ttl",
+            "no shipped automatic",
+            "no server-side event sampling",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, policy.lower())
+        self.assertNotIn("automatic purge runs", policy.lower())
+
+    def test_cross_links_from_events_configuration_and_maintainer(self):
+        for rel in (
+            "docs/events-and-visualization.md",
+            "docs/configuration.md",
+            "docs/MAINTAINER.md",
+        ):
+            if not _exists(rel):
+                self.skipTest(f"{rel} not present in this trimmed fixture")
+        events = _read("docs/events-and-visualization.md")
+        config = _read("docs/configuration.md")
+        maintainer = _read("docs/MAINTAINER.md")
+        readme = _read("docs/README.md") if _exists("docs/README.md") else ""
+        for text in (events, config, maintainer):
+            self.assertIn("observability-retention-policy.md", text)
+        if readme:
+            self.assertIn("observability-retention-policy.md", readme)
+        self.assertIn("OBSERVABILITY_DB_PATH", config)
+
+
+class MatAdoptionObservabilityAppendixTest(unittest.TestCase):
+    """Adoption observability appendix: existence, opt-in honesty, manual rotation, RFU-7 deferral."""
+
+    _APPENDIX_REL = "docs/adoption-observability-appendix.md"
+    _LAYOUT_REL = "scripts/adoption/adoption-layout-v1.json"
+    _PILOT_REPORT_PATH = "artifacts/report/adoption-observability-pilot-2026-06-23.md"
+
+    def test_appendix_exists_with_honesty_strings(self):
+        if not _exists(self._APPENDIX_REL):
+            self.skipTest(f"{self._APPENDIX_REL} not present in this trimmed fixture")
+        appendix = _read(self._APPENDIX_REL)
+        self.assertIn("advisory", appendix.lower())
+        self.assertIn("opt-in", appendix.lower())
+        for phrase in ("manual rotate", "manual rotation", "rotate and prune", "manual prune"):
+            if phrase in appendix.lower():
+                break
+        else:
+            self.fail("appendix must mention manual rotation or rotate/prune")
+        no_purge_phrases = (
+            "no automatic purge",
+            "no automatic ttl",
+            "no shipped automatic",
+            "no auto-purge",
+        )
+        self.assertTrue(
+            any(p in appendix.lower() for p in no_purge_phrases),
+            f"appendix must state no auto-purge/TTL honesty; checked {no_purge_phrases}",
+        )
+        self.assertIn("observability-retention-policy.md", appendix)
+        self.assertTrue(
+            "phase-c-rfu-7" in appendix.lower() or "rfu-7" in appendix.lower(),
+            "appendix must reference RFU-7 deferral",
+        )
+        self.assertIn("events.sqlite", appendix)
+        self.assertIn("OBSERVABILITY_API_TOKEN", appendix)
+        self.assertIn(".mat/docs/adoption-observability-appendix.md", appendix)
+
+    def test_adoption_layout_packages_appendix(self):
+        if not _exists(self._LAYOUT_REL):
+            self.skipTest(f"{self._LAYOUT_REL} not present")
+        layout = _read(self._LAYOUT_REL)
+        self.assertIn("docs/adoption-observability-appendix.md", layout)
+        self.assertIn(".mat/docs/adoption-observability-appendix.md", layout)
+
+    def test_operator_docs_link_adoption_pilot_report(self):
+        """Getting-started, validation-report, and appendix cross-link disposable pilot evidence."""
+        paths = (
+            "docs/getting-started-existing-projects.md",
+            "docs/getting-started-new-projects.md",
+            "validation-report.md",
+            self._APPENDIX_REL,
+        )
+        for rel in paths:
+            with self.subTest(rel=rel):
+                if not _exists(rel):
+                    self.skipTest(f"{rel} not present in this trimmed fixture")
+                text = _read(rel)
+                self.assertIn(self._PILOT_REPORT_PATH, text)
+        appendix = _read(self._APPENDIX_REL)
+        self.assertIn("## Related evidence", appendix)
+
+
+class P2OrchestrationStrategyDocsTest(unittest.TestCase):
+    """P2 Phase A: worktree wrapper + nested/background subagent strategy in decision-record."""
+
+    _WORKTREE_ANCHOR = "p2-audit--worktree-wrapper-strategy"
+    _NESTED_ANCHOR = "p2-audit--nested-and-background-subagents"
+
+    def test_decision_record_p2_sections_with_honesty_strings(self):
+        rel = "docs/decision-record.md"
+        if not _exists(rel):
+            self.skipTest("decision-record.md not present in this trimmed fixture")
+        text = _read(rel)
+        self.assertIn("P2 Audit — Worktree Wrapper Strategy", text)
+        self.assertIn("P2 Audit — Nested and Background Subagents", text)
+        self.assertIn("Hybrid defer", text)
+        self.assertIn("options matrix", text.lower())
+        self.assertIn("/worktree", text)
+        self.assertIn("/best-of-n", text)
+        self.assertIn("Selective use", text)
+        self.assertTrue(
+            "file-first" in text.lower() or "file handoff" in text.lower(),
+            msg="decision-record must mention file-first or file handoff honesty",
+        )
+        self.assertIn("advisory", text.lower())
+        for phrase in (
+            "no live todo spawn",
+            "no hook auto-delegation",
+            "live todo",
+            "hook auto-delegation",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase.lower(), text.lower())
+        overclaim_patterns = (
+            re.compile(r"hook[- ]driven subagent auto[- ]spawn is shipped", re.IGNORECASE),
+            re.compile(r"auto[- ]spawn (?:is|has been) shipped", re.IGNORECASE),
+            re.compile(r"live todo spawn is shipped", re.IGNORECASE),
+            re.compile(r"hooks (?:now )?spawn (?:builder|verifier) automatically", re.IGNORECASE),
+        )
+        nested_start = text.lower().find("p2 audit — nested and background subagents")
+        self.assertGreater(nested_start, -1)
+        nested_block = text[nested_start:]
+        for pattern in overclaim_patterns:
+            with self.subTest(pattern=pattern.pattern):
+                self.assertIsNone(
+                    pattern.search(nested_block),
+                    msg=f"nested-subagent section overclaims auto-spawn: {pattern.pattern}",
+                )
+
+    def test_cross_links_from_roadmap_orchestration_and_audit_report(self):
+        for rel in (
+            "ROADMAP.md",
+            "docs/orchestration-workflow.md",
+            "artifacts/report/mat-audit-report.md",
+        ):
+            if not _exists(rel):
+                self.skipTest(f"{rel} not present in this trimmed fixture")
+        roadmap = _read("ROADMAP.md")
+        orchestration = _read("docs/orchestration-workflow.md")
+        audit = _read("artifacts/report/mat-audit-report.md")
+        for text in (roadmap, orchestration, audit):
+            self.assertIn("decision-record.md", text)
+            self.assertIn(self._WORKTREE_ANCHOR, text)
+            self.assertIn(self._NESTED_ANCHOR, text)
+        self.assertIn("P2OrchestrationStrategyDocsTest", roadmap)
+        self.assertIn("Explicit non-goals", orchestration)
+        self.assertIn("**Done**", audit)
+
+
+# Canonical surfaces for P0-1 worktree contract (aligned with docs/current-plan.md scope).
+_WORKTREE_CONTRACT_REL_PATHS = (
+    "AGENTS.md",
+    "docs/worktree-decision-matrix.md",
+    ".cursor/commands/mat-wt-create.md",
+    ".cursor/commands/mat-wt-list.md",
+    ".cursor/agents/create-worktree-subagent.md",
+    ".cursor/worktrees.json",
+    ".cursor/hooks/bootstrap_worktree.sh",
+    ".cursor/skills/worktree-manager/SKILL.md",
+    ".cursor/skills/create-worktree/SKILL.md",
+    "docs/MAINTAINER.md",
+    "docs/components.md",
+    "docs/getting-started-existing-projects.md",
+    "docs/getting-started-new-projects.md",
+    "docs/configuration.md",
+    "docs/quick-start.md",
+    "docs/best-practices.md",
+    "docs/usage-examples-and-cases.md",
+    "docs/MULTI_AGENT_USAGE_GUIDE.md",
+    "docs/features-demonstrated.md",
+)
+
+_WORKTREE_MISLEADING_PATTERNS = (
+    re.compile(r"Cursor\s+automatically\s+creates\s+a\s+Git\s+worktree", re.IGNORECASE),
+    re.compile(r"automatically\s+creates\s+isolated\s+Git\s+worktrees", re.IGNORECASE),
+    re.compile(r"Each\s+parallel\s+agent\s+run\s+creates\s+a\s+fresh\s+worktree", re.IGNORECASE),
+    re.compile(r"4000\s*\+\s*\(\s*offset\s*\*\s*10", re.IGNORECASE),
+    re.compile(r"4000\s*\+\s*offset\s*\*\s*10", re.IGNORECASE),
+    re.compile(r"base\s*\+\s*\(\s*offset\s*\*\s*10", re.IGNORECASE),
+)
+
+
+class P1StaleDocsHonestyTest(unittest.TestCase):
+    """P1 stale-docs: observability stack honesty, spawn link targets, no snapshot framing."""
+
+    def test_server_readme_describes_shipped_stack_honestly(self):
+        if not _exists("apps/server/README.md"):
+            self.skipTest("apps/server/README.md not present")
+        text = _read("apps/server/README.md")
+        self.assertNotIn("partial snapshot", text.lower())
+        self.assertNotIn("not included as a full app", text.lower())
+        self.assertTrue(
+            any(marker in text for marker in ("/ws/events", "apps/client", "start-system.sh")),
+            msg="server README should reference shipped stack (/ws/events, apps/client, or start-system.sh)",
+        )
+
+    def test_features_demonstrated_does_not_claim_unconfirmed_observability_snapshot(self):
+        if not _exists("docs/features-demonstrated.md"):
+            self.skipTest("features-demonstrated.md not present")
+        text = _read("docs/features-demonstrated.md")
+        self.assertNotIn(
+            "confirmed dependency manifests in this workspace snapshot",
+            text.lower(),
+        )
+        self.assertIn("Full observability stack", text)
+        self.assertIn("Client CI gate", text)
+        self.assertIn("Runtime review panel", text)
+        self.assertIn("MAO visibility panel", text)
+
+    def test_mat_subagents_spawn_related_links_use_mat_prefixed_commands(self):
+        rel = ".cursor/commands/mat-subagents-spawn.md"
+        if not _exists(rel):
+            self.skipTest("mat-subagents-spawn command not present")
+        text = _read(rel)
+        self.assertIn("[`mat-long-run.md`](mat-long-run.md)", text)
+        self.assertIn("[`mat-sprint.md`](mat-sprint.md)", text)
+        self.assertNotIn("(long-run.md)", text)
+        self.assertNotIn("(sprint.md)", text)
+        for target in ("mat-long-run.md", "mat-sprint.md", "mat-plan-team.md"):
+            with self.subTest(target=target):
+                self.assertTrue(
+                    _exists(f".cursor/commands/{target}"),
+                    msg=f"Related link target missing: .cursor/commands/{target}",
+                )
+
+
+# P1 B1 surfaces beyond P0 worktree contract paths (see docs/current-plan.md).
+_P1_WORKTREE_HONESTY_REL_PATHS = (
+    ".cursor/commands/mat-wt-check.md",
+    ".cursor/commands/mat-wt-remove.md",
+    "README.md",
+    "docs/decision-record.md",
+    "docs/orchestration-workflow.md",
+)
+
+# Stop-validator honesty beyond StopValidatorHonestyDocsTest surfaces.
+_P1_STOP_VALIDATOR_HONESTY_REL_PATHS = (
+    "docs/quick-start.md",
+    "docs/pilot-report.md",
+    "docs/phase1-validation-report.md",
+    "docs/MAINTAINER.md",
+)
+
+
+class P1WorktreeValidatorContractDocsTest(unittest.TestCase):
+    """P1 B1: worktree + stop-validator honesty on surfaces beyond P0 contract tests."""
+
+    def test_p1_worktree_surfaces_reject_misleading_patterns_and_hybrid_defer(self):
+        if _is_mat_sidecar_adoption_layout():
+            self.skipTest("MAT sidecar adoption may omit full worktree doc set at repo root")
+
+        missing = [p for p in _P1_WORKTREE_HONESTY_REL_PATHS if not _exists(p)]
+        if missing:
+            self.skipTest("P1 worktree honesty paths missing: " + ", ".join(missing))
+
+        for rel in _P1_WORKTREE_HONESTY_REL_PATHS:
+            text = _read(rel)
+            for pat in _WORKTREE_MISLEADING_PATTERNS:
+                with self.subTest(path=rel, pattern=pat.pattern):
+                    self.assertIsNone(
+                        pat.search(text),
+                        msg=f"{rel} matched misleading pattern {pat.pattern!r}",
+                    )
+
+        decision = _read("docs/decision-record.md")
+        self.assertIn("Hybrid defer", decision)
+        self.assertIn("/worktree", decision)
+        self.assertIn("/best-of-n", decision)
+
+        readme = _read("README.md")
+        self.assertIn("honest boundary", readme.lower())
+        self.assertIn("explicit", readme.lower())
+
+        orchestration = _read("docs/orchestration-workflow.md")
+        self.assertIn("p2-audit--worktree-wrapper-strategy", orchestration)
+        self.assertIn("operator explicitly created isolation", orchestration.lower())
+
+        for rel in (".cursor/commands/mat-wt-check.md", ".cursor/commands/mat-wt-remove.md"):
+            cmd = _read(rel)
+            self.assertIn("worktree", cmd.lower())
+
+    def test_p1_stop_validator_surfaces_document_permissive_shipped_stop(self):
+        missing = [p for p in _P1_STOP_VALIDATOR_HONESTY_REL_PATHS if not _exists(p)]
+        if missing:
+            self.skipTest("P1 stop-validator honesty paths missing: " + ", ".join(missing))
+
+        pilot = _read("docs/pilot-report.md")
+        self.assertIn("send_event.py", pilot)
+        self.assertIn("stop_validator.py", pilot)
+        self.assertIn("failClosed", pilot)
+        self.assertIn("permissive", pilot.lower())
+        self.assertNotIn("blocks completion if required text is missing", pilot.lower())
+        self.assertNotIn("blocks stop if required content is missing", pilot.lower())
+
+        quick_start = _read("docs/quick-start.md")
+        self.assertIn("explicit git worktree", quick_start.lower())
+        self.assertNotIn("blocks completion if", quick_start.lower())
+        self.assertNotIn("validators/", quick_start)
+
+        phase1_report = _read("docs/phase1-validation-report.md")
+        self.assertNotIn("blocks completion", phase1_report.lower())
+        self.assertNotIn("blocks stop if", phase1_report.lower())
+
+        maintainer = _read("docs/MAINTAINER.md")
+        self.assertNotIn("validators/ on shipped `stop`", maintainer.lower())
+        self.assertNotIn("additional commands on the shipped `stop` array", maintainer.lower())
+
+
+_MAT_COMMAND_NAMES = (
+    "mat-plan",
+    "mat-plan-onboarding",
+    "mat-plan-team",
+    "mat-long-run",
+    "mat-build",
+    "mat-review",
+    "mat-subagents-spawn",
+    "mat-sprint",
+    "mat-lite",
+    "mat-wt-create",
+    "mat-wt-list",
+    "mat-wt-remove",
+    "mat-wt-check",
+    "mat-doctor",
+    "mat-start",
+    "mat-update-mat",
+    "mat-git-status",
+    "mat-prime",
+    "mat-question",
+)
+
+_BULK_SKILLS_MIGRATION_PATTERNS = (
+    re.compile(r"all commands (?:were|are) migrated to skills", re.IGNORECASE),
+    re.compile(r"commands removed in favor of skills only", re.IGNORECASE),
+)
+
+_EDITOR_CENTRIC_CLOUD_PATTERNS = (
+    re.compile(r"Settings\s*→\s*Cloud Agents", re.IGNORECASE),
+    re.compile(r"Open Cursor Settings.*Cloud Agents", re.IGNORECASE),
+    re.compile(r"cloud agents in the editor", re.IGNORECASE),
+)
+
+_P1_CLOUD_AGENTS_AUDITED_SURFACES = (
+    "AGENTS.md",
+    "docs/worktree-decision-matrix.md",
+    "docs/components.md",
+    "docs/configuration.md",
+    "docs/technical-stack.md",
+)
+
+
+class P1SkillsCommandsRoutingDocsTest(unittest.TestCase):
+    """P1 Phase B B2: skills vs commands routing in decision-record."""
+
+    _ANCHOR = "p1-audit--skills-vs-commands-routing"
+
+    def test_decision_record_p1_skills_commands_section(self):
+        rel = "docs/decision-record.md"
+        if not _exists(rel):
+            self.skipTest("decision-record.md not present in this trimmed fixture")
+        text = _read(rel)
+        self.assertIn("P1 Audit — Skills vs Commands Routing", text)
+        self.assertIn(self._ANCHOR, text)
+        self.assertIn("Workflow / command", text)
+        self.assertIn("Routing", text)
+        self.assertIn("Rationale", text)
+        self.assertIn("Migration effort", text)
+        for cmd in _MAT_COMMAND_NAMES:
+            with self.subTest(command=cmd):
+                self.assertIn(f"`{cmd}`", text)
+        for skill in ("create-worktree", "worktree-manager", "the-library", "meta-skill"):
+            with self.subTest(skill=skill):
+                self.assertIn(skill, text)
+        self.assertIn("Explicit non-goals", text)
+
+    def test_mat_plan_team_stays_command_and_worktree_skill_cross_ref(self):
+        rel = "docs/decision-record.md"
+        if not _exists(rel):
+            self.skipTest("decision-record.md not present in this trimmed fixture")
+        text = _read(rel)
+        plan_team_idx = text.find("`mat-plan-team`")
+        self.assertGreater(plan_team_idx, -1)
+        plan_team_row = text[plan_team_idx : plan_team_idx + 200]
+        self.assertIn("Keep as command", plan_team_row)
+        self.assertTrue(
+            "create-worktree" in text or "worktree-manager" in text,
+            msg="decision-record must cross-reference worktree skills",
+        )
+        planning = _read("docs/planning-commands-guide.md") if _exists("docs/planning-commands-guide.md") else ""
+        if planning:
+            self.assertIn(self._ANCHOR, planning)
+
+    def test_no_bulk_skills_migration_claim(self):
+        rel = "docs/decision-record.md"
+        if not _exists(rel):
+            self.skipTest("decision-record.md not present in this trimmed fixture")
+        text = _read(rel)
+        section_start = text.lower().find("p1 audit — skills vs commands routing")
+        self.assertGreater(section_start, -1)
+        section = text[section_start:]
+        self.assertIn("Explicit non-goals", section)
+        self.assertIn("No claim that all", section)
+        self.assertIn("No bulk", section)
+        non_goals_start = section.find("### Explicit non-goals")
+        self.assertGreater(non_goals_start, -1)
+        prose_before_non_goals = section[:non_goals_start]
+        for pattern in _BULK_SKILLS_MIGRATION_PATTERNS:
+            with self.subTest(pattern=pattern.pattern):
+                self.assertIsNone(
+                    pattern.search(prose_before_non_goals),
+                    msg="routing prose must not claim bulk command→skill migration",
+                )
+
+
+class P1CloudAgentsAgentsWindowDocsTest(unittest.TestCase):
+    """P1 Phase B B3: Cloud Agents / Agents Window Cursor 3 language."""
+
+    _ANCHOR = "p1-audit--cloud-agents-agents-window"
+
+    def test_decision_record_p1_cloud_agents_section(self):
+        rel = "docs/decision-record.md"
+        if not _exists(rel):
+            self.skipTest("decision-record.md not present in this trimmed fixture")
+        text = _read(rel)
+        self.assertIn("P1 Audit — Cloud Agents and Agents Window", text)
+        self.assertIn(self._ANCHOR, text)
+        self.assertIn("Agents Window", text)
+        self.assertIn(".cursor/environment.json", text)
+        self.assertIn("Explicit non-goals", text)
+        self.assertIn("MAT does not auto-provision", text)
+        self.assertIn("No new cloud automation", text)
+
+    def test_agents_and_worktree_matrix_cursor3_language(self):
+        for rel in ("AGENTS.md", "docs/worktree-decision-matrix.md"):
+            if not _exists(rel):
+                self.skipTest(f"{rel} not present in this trimmed fixture")
+        agents = _read("AGENTS.md")
+        matrix = _read("docs/worktree-decision-matrix.md")
+        for text in (agents, matrix):
+            self.assertIn("Agents Window", text)
+            self.assertIn(".cursor/environment.json", text)
+            self.assertIn(self._ANCHOR, text)
+        self.assertIn("cursor.com/docs/cloud-agent", agents)
+        self.assertNotIn("Settings → Cloud Agents", agents)
+        self.assertNotIn("Settings → Cloud Agents", matrix)
+
+    def test_no_editor_only_cloud_claims(self):
+        missing = [p for p in _P1_CLOUD_AGENTS_AUDITED_SURFACES if not _exists(p)]
+        if missing:
+            self.skipTest("P1 cloud agents audited surfaces missing: " + ", ".join(missing))
+        for rel in _P1_CLOUD_AGENTS_AUDITED_SURFACES:
+            text = _read(rel)
+            for pat in _EDITOR_CENTRIC_CLOUD_PATTERNS:
+                with self.subTest(path=rel, pattern=pat.pattern):
+                    self.assertIsNone(
+                        pat.search(text),
+                        msg=f"{rel} matched editor-centric cloud pattern {pat.pattern!r}",
+                    )
+
+    def test_audit_report_p1_cloud_row_done(self):
+        rel = "artifacts/report/mat-audit-report.md"
+        if not _exists(rel):
+            self.skipTest("mat-audit-report.md not present in this trimmed fixture")
+        text = _read(rel)
+        self.assertIn("Cloud Agents / Agents Window refresh", text)
+        self.assertIn("**Done**", text)
+        self.assertIn(self._ANCHOR, text)
+        self.assertIn("P1CloudAgentsAgentsWindowDocsTest", text)
+
+
+class WorktreeContractDocsTest(unittest.TestCase):
+    """Forbid stale auto-worktree and base-4000 port ladder claims on operator-facing paths."""
+
+    def test_worktree_contract_surfaces_reject_stale_claims(self):
+        if _is_mat_sidecar_adoption_layout():
+            self.skipTest("MAT sidecar adoption may omit full worktree doc set at repo root")
+
+        missing = [p for p in _WORKTREE_CONTRACT_REL_PATHS if not _exists(p)]
+        if missing:
+            self.skipTest("worktree contract paths missing in this fixture: " + ", ".join(missing))
+
+        for rel in _WORKTREE_CONTRACT_REL_PATHS:
+            text = _read(rel)
+            for pat in _WORKTREE_MISLEADING_PATTERNS:
+                with self.subTest(path=rel, pattern=pat.pattern):
+                    self.assertIsNone(
+                        pat.search(text),
+                        msg=f"{rel} matched misleading pattern {pat.pattern!r}",
+                    )
+
+    def test_bootstrap_script_documents_observability_ports(self):
+        if not _exists(".cursor/hooks/bootstrap_worktree.sh"):
+            self.skipTest("bootstrap_worktree.sh not present")
+        text = _read(".cursor/hooks/bootstrap_worktree.sh")
+        self.assertIn("OBSERVABILITY_PORT", text)
+        self.assertIn("OBSERVABILITY_CLIENT_PORT", text)
+        self.assertIn("cksum", text)
+        self.assertIn("3001", text)
+        self.assertIn("5173", text)
+
+    def test_mat_wt_create_documents_runtime_env_contract(self):
+        if not _exists(".cursor/commands/mat-wt-create.md"):
+            self.skipTest("mat-wt-create command not present")
+        text = _read(".cursor/commands/mat-wt-create.md")
+        self.assertIn(".cursor/worktree/runtime.env", text)
+        self.assertIn("OBSERVABILITY_PORT", text)
+        self.assertIn("bootstrap_worktree.sh", text)
+
+
+class RFU3NodePinCiTest(unittest.TestCase):
+    """Phase C C2 (RFU-3): CI pins Node 22 for apps/client toolchain."""
+
+    def test_phase1_verify_workflow_pins_node_22(self):
+        rel = ".github/workflows/phase1-verify.yml"
+        if not _exists(rel):
+            self.skipTest("phase1-verify workflow not present")
+        text = _read(rel)
+        self.assertIn("actions/setup-node@v4", text)
+        self.assertIn("node-version: 22", text)
+        self.assertIn("Vite 8 requires Node 20.19+", text)
+
+
+def _phase1_verify_client_block() -> str:
+    """Extract apps/client block between cd and OK marker in phase1-verify.sh."""
+    text = _read("scripts/phase1-verify.sh")
+    start = text.find('cd "$ROOT/apps/client"')
+    end = text.find("bun observability client: OK")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError("apps/client block markers not found in phase1-verify.sh")
+    return text[start:end]
+
+
+class RFU1VitestOnlyCiTest(unittest.TestCase):
+    """Phase C C3 (RFU-1): vitest-only client tests in phase1-verify.sh."""
+
+    def test_client_block_uses_vitest_not_bun_test(self):
+        if not _exists("scripts/phase1-verify.sh"):
+            self.skipTest("phase1-verify.sh not present")
+        block = _phase1_verify_client_block()
+        self.assertIn("bun run test:vitest", block)
+        for line in block.splitlines():
+            cmd = line.split("#", 1)[0].strip()
+            if cmd == "bun test" or cmd.startswith("bun test "):
+                self.fail(f"standalone bun test must not run in client block: {line!r}")
+
+
+class RFU2FrozenLockfileTest(unittest.TestCase):
+    """Phase C C4 (RFU-2): frozen lockfile install in apps/client block."""
+
+    def test_client_block_uses_frozen_lockfile(self):
+        if not _exists("scripts/phase1-verify.sh"):
+            self.skipTest("phase1-verify.sh not present")
+        block = _phase1_verify_client_block()
+        self.assertIn("bun install --frozen-lockfile", block)
+
+
+class RFU4DependabotConfigTest(unittest.TestCase):
+    """Phase C C5 (RFU-4): dependabot.yml for apps/client npm only."""
+
+    def test_dependabot_config_exists_and_targets_client_only(self):
+        rel = ".github/dependabot.yml"
+        if not _exists(rel):
+            self.skipTest("dependabot.yml not present")
+        text = _read(rel)
+        self.assertIn("package-ecosystem: npm", text)
+        self.assertIn("directory: /apps/client", text)
+        self.assertNotIn("/apps/server", text)
+        self.assertIn("interval: weekly", text)
+        self.assertIn("groups:", text)
+
+
+class RFU1ClientCiDocsHygieneTest(unittest.TestCase):
+    """Phase C C5 doc hygiene: pilot-report matches vitest-only client CI."""
+
+    def test_pilot_report_describes_vitest_only_client_ci(self):
+        if not _exists("docs/pilot-report.md"):
+            self.skipTest("pilot-report.md not present")
+        pilot = _read("docs/pilot-report.md")
+        self.assertIn("test:vitest", pilot)
+        for line in pilot.splitlines():
+            if "apps/client" in line and "bun test" in line:
+                self.fail(
+                    "apps/client must not be paired with bun test in pilot-report: "
+                    f"{line!r}"
+                )
+
+    def test_server_readme_documents_vitest_only_client_ci(self):
+        rel = "apps/server/README.md"
+        if not _exists(rel):
+            self.skipTest("apps/server/README.md not present")
+        text = _read(rel)
+        self.assertIn("test:vitest", text)
+        self.assertIn("vitest-only", text)
+
+
+class MatUpdaterSecurityDocsTest(unittest.TestCase):
+    """MAT updater slice 3: dry-run default, approval gate, no auto-commit, no silent AGENTS overwrite."""
+
+    _DOC_PATHS = (
+        "docs/MAINTAINER.md",
+        "docs/getting-started-existing-projects.md",
+        "docs/adoption-safe-defaults.md",
+        "validation-report.md",
+    )
+
+    def test_updater_security_honesty_strings_across_operator_docs(self):
+        missing = [p for p in self._DOC_PATHS if not _exists(p)]
+        if missing:
+            self.skipTest(f"updater security doc paths missing: {missing}")
+        texts = {p: _read(p) for p in self._DOC_PATHS}
+        combined = "\n".join(texts.values()).lower()
+        self.assertTrue(
+            "dry-run" in combined or "dry run" in combined,
+            "operator docs must describe dry-run-first default",
+        )
+        self.assertIn("--approved", combined, "approval gate (--approved) must be documented")
+        self.assertTrue(
+            "no auto-commit" in combined
+            or "stops before commit" in combined
+            or "stop before commit" in combined,
+            "docs must state updater stops before commit/PR",
+        )
+        self.assertTrue(
+            "no silent" in combined and "agents" in combined
+            or "not silently overwrite" in combined
+            or "product-owned" in combined,
+            "docs must state AGENTS.md is not silently overwritten",
+        )
+        maintainer = texts["docs/MAINTAINER.md"]
+        self.assertIn("MAT updater operator runbook", maintainer)
+        self.assertIn("artifacts/update-mat/", maintainer)
+        validation = texts["validation-report.md"]
+        self.assertIn("Slice 3", validation)
+        self.assertIn("Operator checklist", validation)
+        self.assertIn("getting-started-existing-projects.md", validation)
+        existing = texts["docs/getting-started-existing-projects.md"]
+        self.assertIn(".mat/AGENTS.mat.md", existing)
+        self.assertTrue(
+            "bootstrap before" in existing.lower()
+            or "bootstrap first" in existing.lower()
+            or "requires bootstrap" in existing.lower(),
+            "existing-project guide must state bootstrap before update-mat dry-run",
+        )
+
+
+class MatUpdaterDemoScriptTest(unittest.TestCase):
+    """MAT updater operator demo: script exists, executable, honesty strings."""
+
+    _SCRIPT_REL = "scripts/demo/updater-operator-walkthrough.sh"
+
+    def test_demo_script_exists_executable_and_documents_honesty(self):
+        script_path = REPO_ROOT / self._SCRIPT_REL
+        if not script_path.is_file():
+            self.skipTest(f"{self._SCRIPT_REL} not present")
+        self.assertTrue(os.access(script_path, os.X_OK), "demo script must be executable")
+        text = script_path.read_text(encoding="utf-8")
+        required = (
+            "dry-run",
+            "plan-file=",
+            "patch-file=",
+            "audit-file=",
+            "staging-worktree=",
+            "approval required before commit or PR creation",
+        )
+        for needle in required:
+            self.assertIn(needle, text, f"missing honesty string: {needle}")
+        self.assertTrue(
+            "rev-list --count" in text or "no new commit" in text.lower(),
+            "script must assert no auto-commit on target root",
+        )
+        self.assertIn("demo-walkthrough-latest.md", text)
+        self.assertIn("update-mat.py", text)
+        self.assertIn("--apply", text)
+        self.assertIn("--approved", text)
+        self.assertIn("--plan-file", text)
+
+
+class CIPhase1VerifyCheckoutTest(unittest.TestCase):
+    """CI checkout must fetch full git history for legacy fingerprint verification."""
+
+    def test_phase1_verify_workflow_fetches_full_history(self):
+        rel = ".github/workflows/phase1-verify.yml"
+        if not _exists(rel):
+            self.skipTest("phase1-verify workflow not present")
+        text = _read(rel)
+        self.assertRegex(text, r"fetch-depth:\s*0")
+        self.assertIn("mat-legacy-fingerprints", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent instructions (product-first)
+
+This file is **yours**: document how agents should work in *this* repository — stack, conventions, review rules, and safety boundaries.
+
+## Multi-agent workflow (MAT)
+
+This repo uses the Cursor-native multi-agent workflow. The canonical MAT operator reference lives in **`.mat/AGENTS.mat.md`**.
+
+<!-- MAT_WORKFLOW_POINTER -->
+## Multi-agent workflow (MAT)
+
+This file stays product-owned. The canonical MAT reference lives in `.mat/AGENTS.mat.md`.
+Use the adoption helper's `--inline-fallback` flag only when you need the explicit inline MAT section here.
+<!-- /MAT_WORKFLOW_POINTER -->
+The **`.mat/docs/`** directory holds packaged workflow documentation copied from the MAT reference repository.
+
+- Orchestration handoffs: `docs/current-plan.md`, `build-result.md`, `verify-result.md` at repo root.
+- Long-running missions: `docs/long-run-state.md`.
+- Slash commands and hooks: `.cursor/commands/`, `.cursor/hooks/`.
+Keep product-specific guidance here; use `.mat/AGENTS.mat.md` for the complete MAT encyclopedia without duplicating it into this file.
+<!-- MAT_REFERENCE_NOTE -->
+See `.mat/AGENTS.mat.md` for MAT-specific workflow and agent guidance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,10 @@ Reviewer verification:
 - Block the PR if any forbidden path is present without explicit owner approval.
 - Confirm the PR checklist line for forbidden files is checked.
 
+## Cursor / MAT workflow
+
+This repo uses a tracked MAT sidecar (`.mat/`, `scripts/phase1-verify.sh`, `AGENTS.md` pointer) for multi-agent operator workflows. The `.cursor/` directory (hooks, commands, agents, and repo-local WordPress skills under `.cursor/skills/`) remains **gitignored** unless the project owner explicitly opts into team sharing. After clone, operators run MAT bootstrap locally so `.cursor/` exists on disk; `bash scripts/doctor.sh` validates readiness. Incremental MAT template updates use `scripts/adoption/update-mat.py` (dry-run first); `--apply` is optional and separate from plugin releases. Repo-local skills coexist with the MAT bundle; updater conflicts under `.cursor/skills/` are expected until footprint/preserve policy is chosen. See `docs/mat-adoption-notes.md` for the adoption checklist and `.cursor/` policy options.
+
 ## Review Documents
 
 Use these documents when reviewing or preparing changes:

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,3 +153,18 @@ This documentation is updated with each plugin release. Check the [Changelog](..
 
 **Last Updated**: March 2026  
 **Version**: 1.0.9.1
+
+---
+
+## MAT workflow operator index
+
+Plugin documentation remains in the sections above. For Cursor multi-agent workflow (MAT) operator surfaces in this repo:
+
+| Surface | Link |
+| --- | --- |
+| Mission state | [long-run-state.md](long-run-state.md) — records `execution_mode` and per-slice `execution_rationale`; pair with [`/mat-long-run`](../.cursor/commands/mat-long-run.md) and [parent-orchestrator](../.cursor/agents/parent-orchestrator.md). |
+| Active slice plan | [current-plan.md](current-plan.md) |
+| MAT encyclopedia | [`.mat/AGENTS.mat.md`](../.mat/AGENTS.mat.md) |
+| Observability (opt-in) | [`.mat/docs/adoption-observability-appendix.md`](../.mat/docs/adoption-observability-appendix.md) |
+
+Last updated: 2026-06-24

--- a/docs/current-plan.md
+++ b/docs/current-plan.md
@@ -1,0 +1,41 @@
+# Current plan
+
+## Task
+
+First real MAT adoption on rank-math-api-manager (bootstrap slice on `chore/mat-adoption`).
+
+## DoR
+
+- Bootstrap completed with `bootstrap-workflow-into-repo.sh --mode existing-project --non-interactive`.
+- `.mat/` sidecar and `.cursor/` workflow surfaces exist on disk.
+- `bash scripts/phase1-verify.sh` and `bash scripts/doctor.sh` exit 0 before enabling hooks.
+
+## Binary acceptance criteria
+
+- [x] `.mat/` and `.cursor/` present after bootstrap.
+- [x] `bash scripts/phase1-verify.sh` exits 0.
+- [x] `bash scripts/doctor.sh` exits 0.
+- [x] No plugin PHP modified by bootstrap (`rank-math-api-manager.php` hash unchanged).
+- [x] Single local MAT-only commit on `chore/mat-adoption` (no push unless operator approves).
+
+## Non-goals
+
+- No `update-mat.py --apply` in this slice.
+- No observability apps/server stack (RFU-7 deferred per appendix).
+- No merge of in-flight v1.0.9.2 plugin work into the MAT commit.
+
+## Verification plan
+
+### First slice validation gate
+
+- **PHP syntax:** `php -l` on changed PHP files (matches `.github/workflows/release.yml` intent).
+- **MAT contract:** `bash scripts/phase1-verify.sh`.
+- **Operator readiness:** `bash scripts/doctor.sh`.
+
+### Hooks
+
+Enable incrementally after `doctor` is clean. Review `.cursor/hooks.json` and Python hook dependencies before copying secrets into `.env`.
+
+### Observability
+
+Defer per [`.mat/docs/adoption-observability-appendix.md`](../.mat/docs/adoption-observability-appendix.md): opt-in only, manual `events.sqlite` rotation, no shipped automatic purge.

--- a/docs/current-plan.md
+++ b/docs/current-plan.md
@@ -2,7 +2,7 @@
 
 ## Task
 
-First real MAT adoption on rank-math-api-manager (bootstrap slice on `chore/mat-adoption`).
+Prepare MAT adoption PR on `chore/mat-adoption` (`74cd610` + PR notes). See [mat-adoption-notes.md](mat-adoption-notes.md) for reviewer summary, `.cursor/` coexistence, and checklist.
 
 ## DoR
 

--- a/docs/long-run-state.md
+++ b/docs/long-run-state.md
@@ -1,0 +1,75 @@
+# Long-run mission state
+
+**Purpose:** Minimal valid mission state for adoption smoke fixtures and freshly bootstrapped repos.
+
+**Last updated:** 2026-03-29
+
+---
+
+## Mission
+
+- **Goal:** Validate the non-interactive adoption path in a temporary repository.
+- **execution_mode:** `long-run`
+- **Success signals:** workflow files are present, repo-level contract tests pass, and the fixture remains honest about runtime boundaries.
+
+## Scope / hard constraints / non-goals
+
+- **Hard constraints:** keep file-based MAO handoffs canonical; keep the fixture repo small; avoid staging session outputs under `artifacts/phase1/**`.
+- **Non-goals:** live Cursor todo parity, hook-driven spawn from live todo state, or project-specific feature work.
+
+## Slice preflight decision
+
+- **execution_mode:** `inline`
+- **execution_rationale:** adoption smoke uses the lightest honest execution mode. Other documented slice modes are `builder_plus_verifier` and `parallel_spawn`.
+
+## Ordered slice queue
+
+| # | Slice id | Summary | execution_mode | execution_rationale | Status |
+|---|----------|---------|----------------|---------------------|--------|
+| 1 | `adoption-smoke` | Validate workflow adoption in a temporary repo | `inline` | Smallest bounded fixture path | `pending` |
+| 2 | `reserved-builder` | Reserved example row | `builder_plus_verifier` | Contract text only | `skipped` |
+| 3 | `reserved-parallel` | Reserved example row | `parallel_spawn` | Contract text only | `skipped` |
+
+## Active slice
+
+- **Slice id:** `adoption-smoke`
+- **Pointer:** `docs/current-plan.md`
+- **execution_mode:** `inline`
+- **execution_rationale:** temporary-repo smoke validation only.
+
+## Completed slices
+
+| Slice id | Outcome | `verify-result.md` reference | Notes |
+|----------|---------|------------------------------|-------|
+| | | | |
+
+## Continuation policy
+
+- **Default:** stop after the single adoption fixture slice.
+- **MAO per slice:** if additional slices are added later, keep the canonical tags aligned with the active slice only.
+
+## Stop-reason policy
+
+| Stop reason | Meaning |
+|-------------|---------|
+| `mission_complete` | The adoption fixture is complete. |
+| `hard_blocker` | A required dependency or tool is missing. |
+| `approval_needed` | Human direction is required before continuing. |
+| `planning_gap` | No next slice is defined and the mission is not complete. |
+| `unexpected_termination` | The run ended abnormally. |
+
+---
+
+## Parent mission gate compliance (per verifier PASS)
+
+**Honesty boundary:** Hooks do **not** enforce this gate. Compliance is parent-owned and prompt-disciplined, with regression coverage in `tests/test_workflow_docs.py`.
+
+- [ ] Gate questions answered or one explicit stop reason recorded.
+- [ ] If more slices are later added, queued work is not mislabeled as mission success.
+
+---
+
+## Current stop / continuation (living)
+
+- **Last classified stop reason:** `planning_gap`
+- **Continue:** `no`

--- a/docs/mat-adoption-notes.md
+++ b/docs/mat-adoption-notes.md
@@ -1,0 +1,133 @@
+# MAT adoption notes — rank-math-api-manager
+
+**Branch:** `chore/mat-adoption`  
+**Bootstrap commit:** `74cd610` — `chore: adopt MAT workflow (bootstrap)`  
+**Base:** `origin/main` @ `d59341d` (v1.0.9.1)  
+**MAT source:** `multi-agent-teams` (bootstrap via `bootstrap-workflow-into-repo.sh --mode existing-project`)
+
+This PR adopts the Multi-Agent Teams (MAT) workflow sidecar. It does **not** include v1.0.9.2 product work (composer, PHPUnit, icons, QA workflow, plugin PHP changes).
+
+## What reviewers see in `74cd610`
+
+| Area | Files | Notes |
+| --- | ---: | --- |
+| MAT sidecar | `.mat/**` | Docs, contract tests, `AGENTS.mat.md`, cost-hygiene templates |
+| Product pointer | `AGENTS.md` | Short product-owned stub → `.mat/AGENTS.mat.md` |
+| Operator scripts | `scripts/**` | `phase1-verify.sh`, `doctor.sh`, adoption/updater tooling |
+| Workflow handoffs | `docs/current-plan.md`, `docs/long-run-state.md` | Minimal MAO slice/mission files |
+| Docs index hook | `docs/README.md` | +15 lines: MAT operator index (product docs preserved) |
+| Hygiene | `.cursorignore`, `.env.sample` | Default MAT template (+ WordPress stack lines in follow-up) |
+| Plugin PHP | **0** | No `*.php` in commit |
+
+**Total:** 54 files, ~9.7k insertions, zero deletions of product source.
+
+## `.cursor/` coexistence (on disk, not in commit)
+
+Bootstrap installs MAT workflow surfaces under `.cursor/` (agents, commands, hooks, rules). This repo also has **repo-local WordPress skills** under `.cursor/skills/` (18 skill packages, e.g. `wp-plugin-development`, `wp-rest-api`, `rankmath`).
+
+| Layer | Location | In git today |
+| --- | --- | --- |
+| MAT bundle | `.cursor/agents/`, `commands/`, `hooks/`, `rules/` | **No** — `.cursor/` is in `.gitignore` per `CONTRIBUTING.md` |
+| Repo-local skills | `.cursor/skills/**` | **No** — same ignore rule |
+| MAT sidecar (tracked) | `.mat/` | **Yes** |
+
+Operators need a local bootstrap (or a future policy change) so `.cursor/` exists on disk. `bash scripts/doctor.sh` validates surfaces at the paths above.
+
+### `update-mat.py` dry-run (post-bootstrap, not applied)
+
+```text
+changes detected: 9
+conflicts: 111
+agents_reconciliation_needed: False
+```
+
+Conflicts are **expected**: MAT footprint owns much of `.cursor/`, but **unmanaged** repo-local files under `.cursor/skills/` are not in the MAT manifest. The updater reports them as conflicts until footprint/preserve policy is chosen upstream or locally.
+
+- **`update-mat --apply`** is for **incremental MAT drift refresh** after bootstrap — not required for first adoption.
+- **Do not `--apply`** without reviewing the saved plan and resolving skill coexistence (see options below).
+
+Plan artifact (local): `artifacts/update-mat/plan-update-*.json`
+
+## Policy options for `.cursor/` + skills
+
+### Option A — Keep `.cursor/` gitignored (current; matches `CONTRIBUTING.md`)
+
+- **Pros:** No PR conflict with private-only guardrail; skills and hooks stay machine-local; smallest review surface.
+- **Cons:** Each operator runs bootstrap locally; team drift possible until someone documents the bootstrap command in onboarding.
+- **MAT PR scope:** Commit `.mat/`, `AGENTS.md`, `scripts/`, `.cursorignore`, `.env.sample` only (as in `74cd610`).
+
+### Option B — Selective un-ignore for team sharing
+
+Track MAT-managed workflow files; keep skills private or move skills to a separate tracked path later.
+
+Example `.gitignore` adjustment (illustrative — not applied in bootstrap PR):
+
+```gitignore
+.cursor/
+!.cursor/hooks.json
+!.cursor/mcp.json
+!.cursor/worktrees.json
+!.cursor/agents/
+!.cursor/commands/
+!.cursor/hooks/
+!.cursor/rules/
+# Keep repo-local skills untracked (or move to agent-skills/ with its own policy)
+.cursor/skills/
+```
+
+- **Pros:** Shared slash commands, hooks, and agents across the team without re-bootstrap.
+- **Cons:** Requires `CONTRIBUTING.md` exception, merge discipline on `update-mat`, and explicit preserve rules for `.cursor/skills/`.
+- **When:** After MAT PR merges and operators agree on skill ownership.
+
+**Recommendation for this PR:** **Option A.** Ship the tracked sidecar first; decide Option B in a follow-up slice with an explicit `CONTRIBUTING.md` amendment.
+
+## Cherry-pick onto a clean branch?
+
+| Question | Answer |
+| --- | --- |
+| Is cherry-pick required? | **No** — `chore/mat-adoption` is already **one commit** (`74cd610`) on top of `origin/main` @ `d59341d`. |
+| Does local v1.0.9.2 WIP affect the PR? | **No** — unstaged/modified product files are not in the commit; they will not appear in the GitHub diff if you push only this branch. |
+| When would cherry-pick help? | If the branch later accumulates extra commits, was cut from the wrong base, or you want a new branch name from a freshly fetched `origin/main`. |
+
+**Tradeoffs if you cherry-pick anyway:**
+
+```bash
+git fetch origin
+git checkout -b chore/mat-adoption-clean origin/main
+git cherry-pick 74cd610
+```
+
+- **Pro:** Identical tree to `74cd610`; psychologically “clean” branch from remote main.
+- **Con:** Redundant if `chore/mat-adoption` already matches; any doc commits after `74cd610` must be cherry-picked too or replayed.
+
+## Verification (re-run before PR)
+
+```bash
+bash scripts/phase1-verify.sh   # expect exit 0
+bash scripts/doctor.sh          # expect exit 0
+```
+
+Product PHP validation remains **out of scope** for the MAT PR. For plugin slices, use `php -l` / PHPCS / Plugin Check per `.github/workflows/release.yml`.
+
+## Hooks, observability, cost hygiene
+
+- **Hooks:** Enable incrementally after `doctor` is clean; review `.cursor/hooks.json` and Python deps before `.env` secrets.
+- **Observability:** Opt-in only — see [`.mat/docs/adoption-observability-appendix.md`](../.mat/docs/adoption-observability-appendix.md). RFU-7 deferred; no apps/server stack in this slice.
+- **Cost hygiene:** Bootstrap selected `cursorignore-mat-default`. WordPress-specific lines merged into root `.cursorignore` from `.mat/docs/templates/cursorignore-mat-wordpress` (indexing hygiene only). Strict CI enforcement: `CURSOR_MAT_COST_HYGIENE_ENFORCE` when ready.
+
+## PR readiness checklist
+
+- [ ] PR base: `main` @ `d59341d` (or later release tag if main moved — rebase only if needed)
+- [ ] PR contains **only** MAT commits (`74cd610` + any doc/hygiene follow-ups); no v1.0.9.2 files
+- [ ] `git diff origin/main...HEAD --name-only` shows no `*.php`, no `composer.*`, no `tests/`, no `assets/images/`
+- [ ] `bash scripts/phase1-verify.sh` exit 0 on PR branch
+- [ ] `bash scripts/doctor.sh` exit 0 on PR branch
+- [ ] Reviewer confirms `AGENTS.md` pointer and `.mat/AGENTS.mat.md` split
+- [ ] Reviewer aware `.cursor/` is local-only until Option B
+- [ ] `update-mat.py --apply` **not** run in this PR
+- [ ] CONTRIBUTING private-only guardrail acknowledged (`.cursor/` intentionally absent from diff)
+
+## Related
+
+- Active slice plan: [current-plan.md](current-plan.md)
+- Disposable pilot evidence: MAT repo `artifacts/report/adoption-rank-math-api-manager-pilot-2026-06-24.md`

--- a/scripts/adoption/adoption-layout-v1.json
+++ b/scripts/adoption/adoption-layout-v1.json
@@ -1,0 +1,125 @@
+{
+  "schema_version": "1",
+  "description": "MAT v1 sidecar adoption: machine-readable paths and rules for bootstrap-workflow-into-repo.sh",
+  "root_allowlist": {
+    "dirs": [".cursor/", "scripts/"],
+    "files": [
+      "docs/current-plan.md",
+      "docs/long-run-state.md",
+      ".env.sample",
+      "build-result.md",
+      "verify-result.md"
+    ],
+    "note": "Runtime handoff files are not copied by bootstrap; hooks expect them at repo root when present."
+  },
+  "mat_sidecar": {
+    "readme": ".mat/README.md",
+    "agents_mat": ".mat/AGENTS.mat.md",
+    "docs_dir": ".mat/docs",
+    "tests_dir": ".mat/tests",
+    "vendor_readme_mat": ".mat/vendor/README-MAT.md"
+  },
+  "mat_docs": [
+    { "src": "docs/workflow-artifact-contract.md", "dest": ".mat/docs/workflow-artifact-contract.md" },
+    { "src": "docs/README.md", "dest": ".mat/docs/README.md" },
+    { "src": "docs/components.md", "dest": ".mat/docs/components.md" },
+    { "src": "docs/getting-started-new-projects.md", "dest": ".mat/docs/getting-started-new-projects.md" },
+    { "src": "docs/getting-started-existing-projects.md", "dest": ".mat/docs/getting-started-existing-projects.md" },
+    { "src": "docs/phase4-roadmap-reassessment-checklist.md", "dest": ".mat/docs/phase4-roadmap-reassessment-checklist.md" },
+    { "src": "docs/todo-orchestration-protocol.md", "dest": ".mat/docs/todo-orchestration-protocol.md" },
+    { "src": "docs/update-mat/index.md", "dest": ".mat/docs/update-mat/index.md" },
+    { "src": "docs/update-mat/architecture-and-rollout.md", "dest": ".mat/docs/update-mat/architecture-and-rollout.md" },
+    { "src": "docs/update-mat/role-prompt-templates.md", "dest": ".mat/docs/update-mat/role-prompt-templates.md" },
+    { "src": "docs/update-mat/advisor-task-session-summary.schema.json", "dest": ".mat/docs/update-mat/advisor-task-session-summary.schema.json" },
+    { "src": "docs/update-mat/advisor-task-session-summary.examples.json", "dest": ".mat/docs/update-mat/advisor-task-session-summary.examples.json" },
+    { "src": "docs/templates/cursorignore-mat-default", "dest": ".mat/docs/templates/cursorignore-mat-default" },
+    { "src": "docs/templates/cursorignore-mat-node", "dest": ".mat/docs/templates/cursorignore-mat-node" },
+    { "src": "docs/templates/cursorignore-mat-python", "dest": ".mat/docs/templates/cursorignore-mat-python" },
+    { "src": "docs/templates/cursorignore-mat-wordpress", "dest": ".mat/docs/templates/cursorignore-mat-wordpress" },
+    { "src": "docs/templates/cursorignore-mat-rails", "dest": ".mat/docs/templates/cursorignore-mat-rails" },
+    { "src": "docs/templates/cursorignore-mat-shared.inc", "dest": ".mat/docs/templates/cursorignore-mat-shared.inc" },
+    { "src": "docs/schemas/cost-hygiene-adoption.v1.json", "dest": ".mat/docs/templates/cost-hygiene-adoption.v1.json" },
+    { "src": "docs/adoption-observability-appendix.md", "dest": ".mat/docs/adoption-observability-appendix.md" }
+  ],
+  "mat_tests": [
+    "tests/test_workflow_docs.py",
+    "tests/test_artifact_validation.py"
+  ],
+  "templates": {
+    "minimal_current_plan": "docs/templates/adoption-minimal-current-plan.md",
+    "minimal_long_run_state": "docs/templates/adoption-minimal-long-run-state.md",
+    "product_readme_stub": "docs/templates/adoption-product-readme-stub.md",
+    "agents_product_first": "docs/templates/adoption-AGENTS-product-first.md"
+  },
+  "template_install_targets": {
+    "minimal_current_plan": "docs/current-plan.md",
+    "minimal_long_run_state": "docs/long-run-state.md"
+  },
+  "cursorignore_template_map": {
+    "default": "docs/templates/cursorignore-mat-default",
+    "node": "docs/templates/cursorignore-mat-node",
+    "python": "docs/templates/cursorignore-mat-python",
+    "wordpress": "docs/templates/cursorignore-mat-wordpress",
+    "rails": "docs/templates/cursorignore-mat-rails"
+  },
+  "cursorignore_adoption_schema": "docs/schemas/cost-hygiene-adoption.v1.json",
+  "cursor_copy": {
+    "dir_contents": [
+      ".cursor/agents",
+      ".cursor/commands",
+      ".cursor/hooks",
+      ".cursor/skills"
+    ],
+    "files": [
+      ".cursor/hooks.json",
+      ".cursor/mcp.json",
+      ".cursor/worktrees.json",
+      ".cursor/rules/orchestrator-todos.mdc",
+      ".cursor/rules/cost-context-hygiene.mdc",
+      ".cursor/scripts/validate_artifacts.py"
+    ]
+  },
+  "root_scripts_copy": [
+    "scripts/phase1-verify.sh",
+    "scripts/validate_closeout_coherence.py",
+    "scripts/start-system.sh",
+    "scripts/parallelism-gate.sh",
+    "scripts/check-worktrees.sh",
+    "scripts/doctor.sh",
+    "scripts/setup-dev.sh",
+    "scripts/adoption/migrate-long-run-state.py",
+    "scripts/adoption/manage-agents-sidecars.py",
+    "scripts/adoption/update-mat.py",
+    "scripts/adoption/update_mat_contracts.py",
+    "scripts/adoption/mat-footprint-v1.json",
+    "scripts/adoption/mat-legacy-migrations-v1.json",
+    "scripts/adoption/apply_mat_legacy_cleanup.py",
+    "scripts/adoption/mat-legacy-fingerprints.py",
+    "scripts/adoption/bootstrap-workflow-into-repo.sh",
+    "scripts/adoption/adoption-layout-v1.json",
+    "scripts/adoption/detect_cost_hygiene_template.py",
+    "scripts/adoption/apply_cost_hygiene_bootstrap.py",
+    "scripts/validate_cost_context_hygiene_pack.py"
+  ],
+  "scripts_lib_dir": "scripts/lib",
+  "source_readme_for_vendor": "README.md",
+  "source_agents_for_mat": "AGENTS.md",
+  "modes": {
+    "new-project": {
+      "never_overwrite_root": [],
+      "install_product_readme_stub_if_missing": true,
+      "install_product_agents_if_missing": true,
+      "overwrite_root_agents_if_missing_only": true
+    },
+    "existing-project": {
+      "never_overwrite_root": ["README.md", "CHANGELOG.md", "AGENTS.md"],
+      "install_product_readme_stub_if_missing": true,
+      "install_product_agents_if_missing": true,
+      "overwrite_root_agents_if_missing_only": true
+    }
+  },
+  "denylist_product_root": ["README.md"],
+  "optional_flags": {
+    "inline_fallback": "Write the explicit inline MAT fallback block instead of the default pointer note (legacy alias: --merge-agents)."
+  }
+}

--- a/scripts/adoption/apply_cost_hygiene_bootstrap.py
+++ b/scripts/adoption/apply_cost_hygiene_bootstrap.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Cost hygiene cursorignore + adoption sidecar: called from bootstrap-workflow-into-repo.sh."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Allow `python3 scripts/adoption/apply_cost_hygiene_bootstrap.py` from repo root
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from detect_cost_hygiene_template import detect_cursorignore_template_key  # noqa: E402
+
+
+def _load_layout(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _template_src_for_key(layout: dict[str, Any], key: str) -> str:
+    t = layout["cursorignore_template_map"]
+    if key not in t:
+        raise KeyError(f"unknown template key {key!r} (valid: {sorted(t)!r})")
+    return t[key]
+
+
+def _append_telemetry(dest_root: Path, payload: dict[str, Any]) -> None:
+    outdir = dest_root / "artifacts" / "cost-hygiene"
+    outdir.mkdir(parents=True, exist_ok=True)
+    line = {**payload, "ts_utc": datetime.now(timezone.utc).isoformat()}
+    with (outdir / "bootstrap-events.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps(line, ensure_ascii=False) + "\n")
+
+
+def apply(
+    *,
+    source_root: Path,
+    dest_root: Path,
+    mode: str,
+    layout_path: Path,
+) -> int:
+    layout = _load_layout(layout_path)
+    src_root = source_root.resolve()
+    dest_root = dest_root.resolve()
+    det = detect_cursorignore_template_key(dest_root)
+    key = det.key
+    template_rel = _template_src_for_key(layout, key)
+    mat_docs = dest_root / ".mat" / "docs" / "templates"
+    mat_docs.mkdir(parents=True, exist_ok=True)
+
+    for _tkey, rel in layout["cursorignore_template_map"].items():
+        s = src_root / rel
+        d = mat_docs / Path(rel).name
+        if not s.is_file():
+            print(f"apply_cost_hygiene_bootstrap: missing source template {s}", file=sys.stderr)
+            return 1
+        shutil.copy2(s, d)
+        print(f"bootstrap-workflow-into-repo: copied {rel} -> .mat/docs/templates/{d.name}")
+
+    if layout.get("cursorignore_adoption_schema"):
+        sch = src_root / layout["cursorignore_adoption_schema"]
+        if sch.is_file():
+            dest_sch = mat_docs / sch.name
+            shutil.copy2(sch, dest_sch)
+            rel_p = sch.relative_to(src_root)
+            print(
+                f"bootstrap-workflow-into-repo: copied {rel_p} -> "
+                f"{dest_sch.relative_to(dest_root)}"
+            )
+
+    ignore_path = dest_root / ".cursorignore"
+    root_existed = ignore_path.is_file()
+    sidecar_suggest = True
+
+    if mode == "new-project":
+        enforcement = "strict"
+        if root_existed:
+            preserve = True
+            print("bootstrap-workflow-into-repo: preserving existing .cursorignore (new-project)")
+        else:
+            preserve = False
+            tpl = src_root / template_rel
+            shutil.copy2(tpl, ignore_path)
+            print(
+                f"bootstrap-workflow-into-repo: created .cursorignore from {template_rel} (key={key})"
+            )
+    else:
+        enforcement = "warn_first"
+        if root_existed:
+            preserve = True
+            print("bootstrap-workflow-into-repo: preserving existing .cursorignore (existing-project)")
+        else:
+            preserve = False
+            tpl = src_root / template_rel
+            shutil.copy2(tpl, ignore_path)
+            print(
+                f"bootstrap-workflow-into-repo: created .cursorignore from {template_rel} "
+                f"(key={key}, existing-project — root was absent)"
+            )
+
+    suggest_name = f"cursorignore-mat-{key}.mat-suggest"
+    s_src = src_root / template_rel
+    s_dest = mat_docs / suggest_name
+    shutil.copy2(s_src, s_dest)
+    print(f"bootstrap-workflow-into-repo: wrote {s_dest.relative_to(dest_root)}")
+
+    adoption: dict[str, Any] = {
+        "schema_version": 1,
+        "bootstrap_mode": mode,
+        "enforcement": enforcement,
+        "selected_template": key,
+        "detection_reason": det.reason,
+        "detection_signals": det.signals,
+        "sidecar_suggest_writable": sidecar_suggest,
+        "root_cursorignore_preserved": preserve,
+        "root_cursorignore_created": bool(not root_existed and ignore_path.is_file()),
+    }
+    (dest_root / ".mat").mkdir(parents=True, exist_ok=True)
+    adoption_path = dest_root / ".mat" / "cost-hygiene-adoption.json"
+    adoption_path.write_text(
+        json.dumps(adoption, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"bootstrap-workflow-into-repo: wrote {adoption_path.relative_to(dest_root)}")
+
+    _append_telemetry(
+        dest_root,
+        {
+            "event": "cost_hygiene_bootstrap",
+            "template_key": key,
+            "enforcement": enforcement,
+            "mode": mode,
+        },
+    )
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--source", type=Path, required=True)
+    p.add_argument("--dest", type=Path, required=True)
+    p.add_argument(
+        "--mode", choices=("new-project", "existing-project"), required=True
+    )
+    p.add_argument(
+        "--layout",
+        type=Path,
+        help="Path to adoption-layout-v1.json (default: <source>/scripts/adoption/...)",
+    )
+    args = p.parse_args()
+    src = args.source.resolve()
+    dst = args.dest.resolve()
+    layout_path = args.layout
+    if layout_path is None:
+        layout_path = src / "scripts" / "adoption" / "adoption-layout-v1.json"
+    else:
+        layout_path = args.layout.resolve()
+    if not layout_path.is_file():
+        print(f"apply_cost_hygiene_bootstrap: layout not found: {layout_path}", file=sys.stderr)
+        return 2
+    if not src.is_dir() or not dst.is_dir():
+        print("apply_cost_hygiene_bootstrap: invalid --source or --dest", file=sys.stderr)
+        return 2
+    return apply(source_root=src, dest_root=dst, mode=args.mode, layout_path=layout_path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/adoption/apply_mat_legacy_cleanup.py
+++ b/scripts/adoption/apply_mat_legacy_cleanup.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Apply manifest-driven cleanup of obsolete MAT-managed paths (legacy slash commands, etc.)."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_ADOPTION_DIR = Path(__file__).resolve().parent
+if str(_ADOPTION_DIR) not in sys.path:
+    sys.path.insert(0, str(_ADOPTION_DIR))
+
+from update_mat_contracts import load_footprint_manifest  # noqa: E402
+
+DEFAULT_MANIFEST = Path(__file__).with_name("mat-legacy-migrations-v1.json")
+DEFAULT_FOOTPRINT = Path(__file__).with_name("mat-footprint-v1.json")
+DEFAULT_AUDIT_DIR = "artifacts/update-mat"
+JSONL_NAME = "legacy-cleanup.jsonl"
+QUARANTINE_ROOT = "legacy-quarantine"
+JSONL_RECORD_SCHEMA = "1.0.0"
+
+_ALLOWED_HANDLING = frozenset({"auto_remove", "backup_then_remove", "warn_only"})
+_ALLOWED_FP_SOURCES = frozenset({"git_log_union", "manual", "git_log_union_plus_stub"})
+_PRODUCT_ROOT_NAMES = frozenset({"README.md", "CHANGELOG.md", "AGENTS.md", "ROADMAP.md"})
+_FP_RE = re.compile(r"^[0-9a-f]{64}$")
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+@dataclass(slots=True)
+class CleanupDecision:
+    path: str
+    action: str
+    reason: str
+    successor: str | None
+    handling: str
+    sha256: str | None
+    dry_run: bool
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _normalize_rel(p: str) -> str:
+    """Normalize manifest path segments; keep leading `.cursor/` (do not use lstrip on '.')."""
+    n = p.replace("\\", "/").strip()
+    while n.startswith("./"):
+        n = n[2:]
+    return n
+
+
+def _protected_paths(footprint: dict[str, Any]) -> set[str]:
+    tr = footprint.get("target_repo", {})
+    out: set[str] = set()
+    for key in ("preserve_paths", "protected_handoff_paths"):
+        raw = tr.get(key)
+        if isinstance(raw, list):
+            for item in raw:
+                if isinstance(item, str) and item.strip():
+                    out.add(_normalize_rel(item.strip()))
+    return out
+
+
+def load_migration_manifest(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema_version") != "1.0.0":
+        raise ValueError(f"unsupported mat-legacy-migrations schema: {data.get('schema_version')}")
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("migration manifest missing entries array")
+    return data
+
+
+def validate_mat_legacy_migrations(migration: dict[str, Any], *, footprint: dict[str, Any]) -> None:
+    """Validate manifest shape, fingerprints, handling modes, and blocked product / footprint paths."""
+    if migration.get("schema_version") != "1.0.0":
+        raise ValueError(f"unsupported mat-legacy-migrations schema: {migration.get('schema_version')}")
+    entries = migration.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("migration manifest missing entries array")
+    protected = _protected_paths(footprint)
+    seen_paths: set[str] = set()
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ValueError(f"entries[{i}] must be a JSON object")
+        path_raw = entry.get("path")
+        if not isinstance(path_raw, str) or not path_raw.strip():
+            raise ValueError(f"entries[{i}] missing non-empty string path")
+        rel = _normalize_rel(path_raw)
+        if rel in seen_paths:
+            raise ValueError(f"entries[{i}] duplicate path {rel!r}")
+        seen_paths.add(rel)
+        if rel in protected:
+            raise ValueError(
+                f"entries[{i}] path {rel!r} is blocked: overlaps mat-footprint "
+                "preserve_paths or protected_handoff_paths",
+            )
+        if "/" not in rel and rel in _PRODUCT_ROOT_NAMES:
+            raise ValueError(
+                f"entries[{i}] path {rel!r} is blocked: enumerated product-owned root filename",
+            )
+        handling = entry.get("handling", "warn_only")
+        if not isinstance(handling, str) or handling not in _ALLOWED_HANDLING:
+            raise ValueError(
+                f"entries[{i}] handling must be one of {sorted(_ALLOWED_HANDLING)}; got {handling!r}",
+            )
+        fps_raw = entry.get("fingerprints")
+        if fps_raw is None:
+            raise ValueError(f"entries[{i}] missing fingerprints array (use [] for warn_only)")
+        if not isinstance(fps_raw, list):
+            raise ValueError(f"entries[{i}] fingerprints must be a JSON array")
+        for j, fp in enumerate(fps_raw):
+            if not isinstance(fp, str) or not _FP_RE.match(fp):
+                raise ValueError(
+                    f"entries[{i}] fingerprints[{j}] must be a 64-character lowercase hexadecimal sha256 string",
+                )
+        if handling in {"auto_remove", "backup_then_remove"} and len(fps_raw) == 0:
+            raise ValueError(
+                f"entries[{i}] handling={handling!r} requires at least one fingerprint "
+                "(use warn_only when canonical bytes are unknown)",
+            )
+        if "successor" in entry and entry["successor"] is not None:
+            succ = entry["successor"]
+            if not isinstance(succ, str) or not succ.strip():
+                raise ValueError(f"entries[{i}] successor must be a non-empty string when set")
+            s = _normalize_rel(succ)
+            if s.startswith("/"):
+                raise ValueError(f"entries[{i}] successor must be a relative repository path")
+            if "\\" in succ:
+                raise ValueError(f"entries[{i}] successor must use forward slashes only")
+            if ".." in Path(s).parts:
+                raise ValueError(f"entries[{i}] successor must not contain parent-directory segments")
+        prov_raw = entry.get("fingerprint_provenance")
+        needs_provenance = handling in {"auto_remove", "backup_then_remove"} and len(fps_raw) > 0
+        if needs_provenance and prov_raw is None:
+            raise ValueError(
+                f"entries[{i}] with handling={handling!r} and non-empty fingerprints "
+                "requires fingerprint_provenance",
+            )
+        if prov_raw is not None:
+            if not isinstance(prov_raw, dict):
+                raise ValueError(f"entries[{i}] fingerprint_provenance must be a JSON object")
+            source = prov_raw.get("source")
+            if not isinstance(source, str) or source not in _ALLOWED_FP_SOURCES:
+                raise ValueError(
+                    f"entries[{i}] fingerprint_provenance.source must be one of "
+                    f"{sorted(_ALLOWED_FP_SOURCES)}; got {source!r}",
+                )
+            boundary = prov_raw.get("boundary")
+            if not isinstance(boundary, str) or not boundary.strip():
+                raise ValueError(f"entries[{i}] fingerprint_provenance.boundary must be a non-empty string")
+            generated_at = prov_raw.get("generated_at")
+            if not isinstance(generated_at, str) or not _ISO_DATE_RE.match(generated_at):
+                raise ValueError(
+                    f"entries[{i}] fingerprint_provenance.generated_at must be ISO date YYYY-MM-DD",
+                )
+            if "note" in prov_raw and prov_raw["note"] is not None:
+                if not isinstance(prov_raw["note"], str):
+                    raise ValueError(f"entries[{i}] fingerprint_provenance.note must be a string when set")
+
+
+def apply_legacy_cleanup(
+    *,
+    repo_root: Path,
+    migration_manifest_path: Path,
+    footprint_manifest_path: Path,
+    audit_dir_rel: str = DEFAULT_AUDIT_DIR,
+    dry_run: bool = False,
+    run_id: str | None = None,
+) -> list[CleanupDecision]:
+    repo_root = repo_root.resolve()
+    migration = load_migration_manifest(migration_manifest_path)
+    footprint = load_footprint_manifest(footprint_manifest_path)
+    validate_mat_legacy_migrations(migration, footprint=footprint)
+
+    stamp = run_id or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    audit_root = repo_root / audit_dir_rel
+    jsonl_path = audit_root / JSONL_NAME
+    quarantine_base = audit_root / QUARANTINE_ROOT / stamp
+    if not dry_run:
+        audit_root.mkdir(parents=True, exist_ok=True)
+
+    decisions: list[CleanupDecision] = []
+    manifest_schema = str(migration.get("schema_version", ""))
+
+    def append_jsonl(d: CleanupDecision) -> None:
+        record = {
+            "action": d.action,
+            "dry_run": d.dry_run,
+            "handling": d.handling,
+            "legacy_cleanup_jsonl_schema": JSONL_RECORD_SCHEMA,
+            "manifest_schema_version": manifest_schema,
+            "path": d.path,
+            "reason": d.reason,
+            "run_id": stamp,
+            "sha256": d.sha256,
+            "successor": d.successor,
+        }
+        line = json.dumps(record, sort_keys=True)
+        if not dry_run:
+            with jsonl_path.open("a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+
+    for entry in migration["entries"]:
+        rel = _normalize_rel(str(entry["path"]))
+        successor = entry.get("successor")
+        successor_s = str(successor).strip() if isinstance(successor, str) else None
+        handling = str(entry.get("handling", "warn_only"))
+        fps_raw = entry.get("fingerprints")
+        fingerprints: set[str] = set()
+        if isinstance(fps_raw, list):
+            fingerprints.update(str(x).lower() for x in fps_raw if isinstance(x, str) and _FP_RE.match(str(x)))
+
+        target = repo_root / rel
+
+        if target.exists() and not target.is_file():
+            d = CleanupDecision(
+                path=rel,
+                action="skipped_not_file",
+                reason="path exists but is not a regular file",
+                successor=successor_s,
+                handling=handling,
+                sha256=None,
+                dry_run=dry_run,
+            )
+            decisions.append(d)
+            append_jsonl(d)
+            continue
+
+        if not target.is_file():
+            d = CleanupDecision(
+                path=rel,
+                action="skipped_absent",
+                reason="file does not exist",
+                successor=successor_s,
+                handling=handling,
+                sha256=None,
+                dry_run=dry_run,
+            )
+            decisions.append(d)
+            append_jsonl(d)
+            continue
+
+        sha = _sha256_file(target)
+        matched = sha.lower() in fingerprints
+
+        if handling == "warn_only":
+            msg = f"[mat-legacy-cleanup] obsolete path present: {rel} (successor: {successor_s or 'n/a'}) — review manually; not removed (warn_only)."
+            print(msg, file=sys.stderr)
+            d = CleanupDecision(
+                path=rel,
+                action="warn_only",
+                reason="handling mode is warn_only",
+                successor=successor_s,
+                handling=handling,
+                sha256=sha,
+                dry_run=dry_run,
+            )
+            decisions.append(d)
+            append_jsonl(d)
+            continue
+
+        if handling == "auto_remove":
+            if not matched:
+                d = CleanupDecision(
+                    path=rel,
+                    action="skipped_customized",
+                    reason="content does not match any fingerprint; auto_remove refuses without proof",
+                    successor=successor_s,
+                    handling=handling,
+                    sha256=sha,
+                    dry_run=dry_run,
+                )
+                decisions.append(d)
+                append_jsonl(d)
+                continue
+            if dry_run:
+                d = CleanupDecision(
+                    path=rel,
+                    action="would_remove",
+                    reason="fingerprint matched; dry_run",
+                    successor=successor_s,
+                    handling=handling,
+                    sha256=sha,
+                    dry_run=True,
+                )
+            else:
+                target.unlink()
+                d = CleanupDecision(
+                    path=rel,
+                    action="removed",
+                    reason="fingerprint matched auto_remove",
+                    successor=successor_s,
+                    handling=handling,
+                    sha256=sha,
+                    dry_run=False,
+                )
+            decisions.append(d)
+            append_jsonl(d)
+            continue
+
+        if handling == "backup_then_remove":
+            if matched:
+                dest = quarantine_base / rel
+                if dry_run:
+                    d = CleanupDecision(
+                        path=rel,
+                        action="would_quarantine_and_remove",
+                        reason="fingerprint matched; dry_run",
+                        successor=successor_s,
+                        handling=handling,
+                        sha256=sha,
+                        dry_run=True,
+                    )
+                else:
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(target, dest)
+                    target.unlink()
+                    d = CleanupDecision(
+                        path=rel,
+                        action="quarantined_and_removed",
+                        reason=f"matched fingerprint; backup at {(dest.relative_to(repo_root)).as_posix()}",
+                        successor=successor_s,
+                        handling=handling,
+                        sha256=sha,
+                        dry_run=False,
+                    )
+                decisions.append(d)
+                append_jsonl(d)
+                continue
+
+            dest = quarantine_base / f"customized-{Path(rel).name}"
+            if dry_run:
+                d = CleanupDecision(
+                    path=rel,
+                    action="would_quarantine_customized",
+                    reason="content differs from fingerprints; would copy to quarantine only (original kept)",
+                    successor=successor_s,
+                    handling=handling,
+                    sha256=sha,
+                    dry_run=True,
+                )
+            else:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(target, dest)
+                print(
+                    f"[mat-legacy-cleanup] customized legacy file left in place: {rel} "
+                    f"(review copy under {dest.relative_to(repo_root).as_posix()})",
+                    file=sys.stderr,
+                )
+                d = CleanupDecision(
+                    path=rel,
+                    action="quarantined_customized_left_in_place",
+                    reason="content differs from fingerprints; original retained",
+                    successor=successor_s,
+                    handling=handling,
+                    sha256=sha,
+                    dry_run=False,
+                )
+            decisions.append(d)
+            append_jsonl(d)
+            continue
+
+        d = CleanupDecision(
+            path=rel,
+            action="skipped_unknown_handling",
+            reason=f"unknown handling mode: {handling}",
+            successor=successor_s,
+            handling=handling,
+            sha256=sha,
+            dry_run=dry_run,
+        )
+        decisions.append(d)
+        append_jsonl(d)
+
+    return decisions
+
+
+def print_legacy_cleanup_report(*, repo_root: Path, audit_dir_rel: str) -> None:
+    """Summarize the latest run_id slice in legacy-cleanup.jsonl (stdout)."""
+    jsonl_path = repo_root / audit_dir_rel / JSONL_NAME
+    if not jsonl_path.is_file():
+        print(f"No audit file at {jsonl_path}")
+        return
+    lines = [ln for ln in jsonl_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    if not lines:
+        print("legacy-cleanup.jsonl is empty")
+        return
+    rows: list[dict[str, Any]] = []
+    for ln in lines:
+        try:
+            rows.append(json.loads(ln))
+        except json.JSONDecodeError:
+            print(f"legacy-cleanup.jsonl contains invalid JSON line (skipped): {ln[:120]!r}")
+    if not rows:
+        return
+    last_id = rows[-1].get("run_id", "(legacy records without run_id)")
+    scoped = [r for r in rows if r.get("run_id") == last_id] or rows
+    actions = Counter(str(r.get("action")) for r in scoped)
+    print(f"legacy cleanup report: last run_id={last_id!r} (lines={len(scoped)})")
+    for act, n in sorted(actions.items()):
+        print(f"  {act}: {n}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Remove or quarantine obsolete MAT legacy paths per mat-legacy-migrations manifest.")
+    p.add_argument("--repo-root", default=".", help="Adopted repository root.")
+    p.add_argument("--manifest", default=str(DEFAULT_MANIFEST), help="mat-legacy-migrations JSON path.")
+    p.add_argument("--footprint", default=str(DEFAULT_FOOTPRINT), help="mat-footprint-v1.json path.")
+    p.add_argument("--audit-dir", default=DEFAULT_AUDIT_DIR, help="Audit directory relative to repo root.")
+    p.add_argument("--dry-run", action="store_true", help="Log decisions only; no file mutations.")
+    p.add_argument(
+        "--report",
+        action="store_true",
+        help="Print a summary of legacy-cleanup.jsonl under --audit-dir (no cleanup).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    repo = Path(args.repo_root).expanduser().resolve()
+    if args.report:
+        print_legacy_cleanup_report(repo_root=repo, audit_dir_rel=args.audit_dir)
+        return 0
+    manifest = Path(args.manifest).expanduser().resolve()
+    footprint = Path(args.footprint).expanduser().resolve()
+    try:
+        apply_legacy_cleanup(
+            repo_root=repo,
+            migration_manifest_path=manifest,
+            footprint_manifest_path=footprint,
+            audit_dir_rel=args.audit_dir,
+            dry_run=args.dry_run,
+        )
+    except Exception as exc:
+        print(f"apply_mat_legacy_cleanup: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/adoption/bootstrap-workflow-into-repo.sh
+++ b/scripts/adoption/bootstrap-workflow-into-repo.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  bootstrap-workflow-into-repo.sh [--mode new-project|existing-project] [--non-interactive] [--inline-fallback] <destination-repo>
+
+  --inline-fallback   Write the explicit inline MAT fallback block instead of the default pointer note.
+
+Environment:
+  MULTI_AGENT_WORKFLOW_ROOT   Optional source repo root. Defaults to the repo that contains this script.
+EOF
+}
+
+MODE="existing-project"
+NON_INTERACTIVE=0
+INLINE_FALLBACK=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --mode)
+      shift
+      MODE="${1:-}"
+      ;;
+    --mode=*)
+      MODE="${1#--mode=}"
+      ;;
+    --non-interactive)
+      NON_INTERACTIVE=1
+      ;;
+    --inline-fallback|--merge-agents)
+      INLINE_FALLBACK=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "bootstrap-workflow-into-repo: unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+  shift
+done
+
+if [ $# -ne 1 ]; then
+  usage
+  exit 2
+fi
+
+case "$MODE" in
+  new-project|existing-project) ;;
+  *)
+    echo "bootstrap-workflow-into-repo: unsupported mode '$MODE'" >&2
+    exit 2
+    ;;
+esac
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_ROOT="${MULTI_AGENT_WORKFLOW_ROOT:-$SCRIPT_ROOT}"
+DEST_INPUT="$1"
+LAYOUT_JSON="$SOURCE_ROOT/scripts/adoption/adoption-layout-v1.json"
+
+if [ ! -f "$LAYOUT_JSON" ]; then
+  echo "bootstrap-workflow-into-repo: missing layout contract: $LAYOUT_JSON" >&2
+  exit 2
+fi
+
+if [ ! -f "$SOURCE_ROOT/AGENTS.md" ] || [ ! -d "$SOURCE_ROOT/.cursor" ]; then
+  echo "bootstrap-workflow-into-repo: invalid workflow source: $SOURCE_ROOT" >&2
+  exit 2
+fi
+
+mkdir -p "$DEST_INPUT"
+DEST_ROOT="$(cd "$DEST_INPUT" && pwd)"
+
+copy_source_to_dest() {
+  local rel_src="$1"
+  local rel_dest="$2"
+  mkdir -p "$DEST_ROOT/$(dirname "$rel_dest")"
+  cp "$SOURCE_ROOT/$rel_src" "$DEST_ROOT/$rel_dest"
+}
+
+copy_dir_contents() {
+  local rel_dir="$1"
+  mkdir -p "$DEST_ROOT/$rel_dir"
+  cp -R "$SOURCE_ROOT/$rel_dir/." "$DEST_ROOT/$rel_dir/"
+}
+
+install_template_if_missing() {
+  local template_rel="$1"
+  local target_rel="$2"
+  if [ -e "$DEST_ROOT/$target_rel" ]; then
+    echo "bootstrap-workflow-into-repo: preserving existing $target_rel"
+    return 0
+  fi
+  mkdir -p "$DEST_ROOT/$(dirname "$target_rel")"
+  cp "$SOURCE_ROOT/$template_rel" "$DEST_ROOT/$target_rel"
+  echo "bootstrap-workflow-into-repo: created $target_rel"
+}
+
+write_mat_readme() {
+  mkdir -p "$DEST_ROOT/.mat"
+  cat <<'EOF' >"$DEST_ROOT/.mat/README.md"
+# `.mat/` — Multi-agent workflow (MAT) sidecar
+
+This directory holds **MAT-packaged** material for this repository: reference documentation and workflow contract tests copied from the MAT source repo. It keeps product documentation at the repo root separate from workflow manuals.
+
+- **`.mat/docs/`** — packaged workflow documentation (components, getting started, MAO protocol, [workflow-artifact-contract.md](docs/workflow-artifact-contract.md) for `build-result.md` / `verify-result.md` section contracts, etc.).
+- **`.mat/tests/`** — workflow contract tests (`unittest`); run with `python3 -m unittest discover -s .mat/tests -p 'test_*.py' -v`.
+- **`.mat/AGENTS.mat.md`** — full MAT operator reference from the source `AGENTS.md`.
+- **`.mat/vendor/README-MAT.md`** — optional attribution copy of the MAT source `README.md`.
+
+Entrypoints at repo root: **`scripts/phase1-verify.sh`**, **`.cursor/`** (hooks, commands, agents).
+
+`phase1-verify.sh` detects this sidecar (presence of this file) and then: validates workflow markdown with **optional** `build-result.md` / `verify-result.md` when those handoffs are absent, skips closeout posture checks until `artifacts/agent-traces/comparison.json` exists, runs **`python3 -m unittest discover -s .mat/tests`** (not the product’s `tests/` tree), and skips the Bun observability smoke when `apps/server` is not packaged.
+
+For product narrative, use the root **`README.md`** and your application docs — not this tree.
+EOF
+}
+
+# --- Layout-driven copies (single source of truth: adoption-layout-v1.json) ---
+
+python3 - "$LAYOUT_JSON" "$SOURCE_ROOT" "$DEST_ROOT" <<'PY'
+import json
+import pathlib
+import shutil
+import sys
+
+layout_path, source_root, dest_root = sys.argv[1:4]
+layout = json.loads(pathlib.Path(layout_path).read_text(encoding="utf-8"))
+src = pathlib.Path(source_root)
+dst = pathlib.Path(dest_root)
+
+for item in layout["mat_docs"]:
+    s, d = item["src"], item["dest"]
+    pathlib.Path(dst / d).parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src / s, dst / d)
+    print(f"bootstrap-workflow-into-repo: copied {s} -> {d}")
+
+for rel in layout["mat_tests"]:
+    dest = pathlib.Path(".mat/tests") / pathlib.Path(rel).name
+    pathlib.Path(dst / dest).parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src / rel, dst / dest)
+    print(f"bootstrap-workflow-into-repo: copied {rel} -> {dest}")
+
+pathlib.Path(dst / ".mat/vendor").mkdir(parents=True, exist_ok=True)
+vendor_src = layout.get("source_readme_for_vendor", "README.md")
+vendor_dest = layout["mat_sidecar"]["vendor_readme_mat"]
+shutil.copy2(src / vendor_src, dst / vendor_dest)
+print(f"bootstrap-workflow-into-repo: copied {vendor_src} -> {vendor_dest}")
+
+agents_mat = layout["mat_sidecar"]["agents_mat"]
+shutil.copy2(src / layout["source_agents_for_mat"], dst / agents_mat)
+print(f"bootstrap-workflow-into-repo: wrote {agents_mat} from {layout['source_agents_for_mat']}")
+PY
+
+write_mat_readme
+
+for rel_dir in $(
+  python3 -c "import json, pathlib; l=json.load(open(pathlib.Path('$LAYOUT_JSON'))); print(' '.join(l['cursor_copy']['dir_contents']))"
+); do
+  copy_dir_contents "$rel_dir"
+done
+
+for rel_path in $(
+  python3 -c "import json, pathlib; l=json.load(open(pathlib.Path('$LAYOUT_JSON'))); print(' '.join(l['cursor_copy']['files']))"
+); do
+  copy_source_to_dest "$rel_path" "$rel_path"
+done
+
+# Point copied `.cursor/` prompts at the packaged contract under `.mat/docs/` when root `docs/` is minimal.
+python3 - "$DEST_ROOT" <<'PY'
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+dest_root = pathlib.Path(sys.argv[1]).resolve()
+cursor_root = dest_root / ".cursor"
+if not cursor_root.is_dir():
+    raise SystemExit(0)
+
+_STANDALONE_ROOT_DOCS = re.compile(
+    r"(?<!\.mat/)docs/workflow-artifact-contract\.md"
+)
+
+
+def rewrite_text(text: str) -> str:
+    text = text.replace(
+        "../../docs/workflow-artifact-contract.md",
+        "../../.mat/docs/workflow-artifact-contract.md",
+    )
+    text = _STANDALONE_ROOT_DOCS.sub(
+        ".mat/docs/workflow-artifact-contract.md",
+        text,
+    )
+    return text
+
+changed = 0
+for path in sorted(cursor_root.rglob("*")):
+    if not path.is_file():
+        continue
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        continue
+    new = rewrite_text(raw)
+    if new != raw:
+        path.write_text(new, encoding="utf-8")
+        changed += 1
+print(f"bootstrap-workflow-into-repo: rewrote workflow-artifact-contract paths in {changed} files under .cursor/")
+PY
+
+for rel_path in $(
+  python3 -c "import json, pathlib; l=json.load(open(pathlib.Path('$LAYOUT_JSON'))); print(' '.join(l['root_scripts_copy']))"
+); do
+  copy_source_to_dest "$rel_path" "$rel_path"
+done
+
+copy_dir_contents "$(
+  python3 -c "import json, pathlib; print(json.load(open(pathlib.Path('$LAYOUT_JSON')))['scripts_lib_dir'])"
+)"
+
+copy_source_to_dest ".env.sample" ".env.sample"
+
+# Root handoff templates (minimal workflow contract only at docs/)
+# (Must not use a shell pipeline here: install_template_if_missing is a bash function and is not
+# available in the subshell spawned by `|`.)
+python3 - "$LAYOUT_JSON" "$SOURCE_ROOT" "$DEST_ROOT" <<'PY'
+import json
+import pathlib
+import shutil
+import sys
+
+layout_path, source_root, dest_root = sys.argv[1:4]
+layout = json.loads(pathlib.Path(layout_path).read_text(encoding="utf-8"))
+src = pathlib.Path(source_root)
+dst = pathlib.Path(dest_root)
+t = layout["templates"]
+x = layout["template_install_targets"]
+for key in ("minimal_current_plan", "minimal_long_run_state"):
+    rel_t = t[key]
+    rel_target = x[key]
+    target = dst / rel_target
+    if target.exists():
+        print(f"bootstrap-workflow-into-repo: preserving existing {rel_target}")
+        continue
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src / rel_t, target)
+    print(f"bootstrap-workflow-into-repo: created {rel_target}")
+PY
+
+python3 "$SOURCE_ROOT/scripts/adoption/apply_cost_hygiene_bootstrap.py" \
+  --source "$SOURCE_ROOT" \
+  --dest "$DEST_ROOT" \
+  --mode "$MODE" \
+  --layout "$LAYOUT_JSON"
+
+# Product-first README stub when missing (never MAT marketing README at root)
+install_template_if_missing "$(
+  python3 -c "import json, pathlib; print(json.load(open(pathlib.Path('$LAYOUT_JSON')))['templates']['product_readme_stub'])"
+)" "README.md"
+
+# Root AGENTS.md: product-first template when missing; never overwrite existing in existing-project
+PRODUCT_AGENTS="$(
+  python3 -c "import json, pathlib; print(json.load(open(pathlib.Path('$LAYOUT_JSON')))['templates']['agents_product_first'])"
+)"
+
+if [ ! -f "$DEST_ROOT/AGENTS.md" ]; then
+  mkdir -p "$DEST_ROOT"
+  cp "$SOURCE_ROOT/$PRODUCT_AGENTS" "$DEST_ROOT/AGENTS.md"
+  echo "bootstrap-workflow-into-repo: created AGENTS.md from product-first template"
+else
+  echo "bootstrap-workflow-into-repo: preserving existing AGENTS.md"
+fi
+
+HELPER_ARGS=(--repo-root "$DEST_ROOT")
+if [ "$INLINE_FALLBACK" = "1" ]; then
+  HELPER_ARGS+=(--inline-fallback)
+fi
+python3 "$SOURCE_ROOT/scripts/adoption/manage-agents-sidecars.py" "${HELPER_ARGS[@]}"
+
+python3 "$SOURCE_ROOT/scripts/adoption/apply_mat_legacy_cleanup.py" \
+  --repo-root "$DEST_ROOT" \
+  --manifest "$DEST_ROOT/scripts/adoption/mat-legacy-migrations-v1.json" \
+  --footprint "$DEST_ROOT/scripts/adoption/mat-footprint-v1.json" \
+  --audit-dir artifacts/update-mat
+
+chmod +x \
+  "$DEST_ROOT/scripts/phase1-verify.sh" \
+  "$DEST_ROOT/scripts/start-system.sh" \
+  "$DEST_ROOT/scripts/parallelism-gate.sh" \
+  "$DEST_ROOT/scripts/check-worktrees.sh" \
+  "$DEST_ROOT/scripts/doctor.sh" \
+  "$DEST_ROOT/scripts/setup-dev.sh" \
+  "$DEST_ROOT/.cursor/hooks/bootstrap_worktree.sh"
+
+chmod +x "$DEST_ROOT/scripts/adoption/migrate-long-run-state.py"
+chmod +x "$DEST_ROOT/scripts/adoption/bootstrap-workflow-into-repo.sh"
+chmod +x "$DEST_ROOT/scripts/adoption/apply_mat_legacy_cleanup.py"
+chmod +x "$DEST_ROOT/scripts/adoption/mat-legacy-fingerprints.py"
+chmod +x "$DEST_ROOT/scripts/adoption/apply_cost_hygiene_bootstrap.py"
+chmod +x "$DEST_ROOT/scripts/adoption/detect_cost_hygiene_template.py"
+
+echo "bootstrap-workflow-into-repo: source=$SOURCE_ROOT"
+echo "bootstrap-workflow-into-repo: destination=$DEST_ROOT"
+echo "bootstrap-workflow-into-repo: mode=$MODE"
+if [ "$NON_INTERACTIVE" = "1" ]; then
+  echo "bootstrap-workflow-into-repo: non-interactive=yes"
+fi
+if [ "$INLINE_FALLBACK" = "1" ]; then
+  echo "bootstrap-workflow-into-repo: inline-fallback=yes"
+fi

--- a/scripts/adoption/detect_cost_hygiene_template.py
+++ b/scripts/adoption/detect_cost_hygiene_template.py
@@ -1,0 +1,78 @@
+"""Deterministic .cursorignore template key selection for MAT cost hygiene (bootstrap + tests)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+# Keys must match adoption layout `cursorignore_template_keys` / validator template list
+TEMPLATE_WORDPRESS = "wordpress"
+TEMPLATE_RAILS = "rails"
+TEMPLATE_NODE = "node"
+TEMPLATE_PYTHON = "python"
+TEMPLATE_DEFAULT = "default"
+
+ALL_STACK_KEYS: tuple[str, ...] = (
+    TEMPLATE_DEFAULT,
+    TEMPLATE_NODE,
+    TEMPLATE_PYTHON,
+    TEMPLATE_RAILS,
+    TEMPLATE_WORDPRESS,
+)
+
+
+@dataclass
+class TemplateDetection:
+    key: str
+    reason: str
+    signals: dict[str, bool] = field(default_factory=dict)
+    as_dict: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.as_dict = {
+            "key": self.key,
+            "reason": self.reason,
+            "signals": dict(self.signals),
+        }
+
+
+def detect_cursorignore_template_key(root: Path) -> TemplateDetection:
+    """Select template key. Priority: WordPress → Rails (explicit app) → Node (package.json) → Python.
+
+    Ambiguous repos fall back to the generic default. ``Gemfile`` without Node markers selects
+    the Rails-oriented template (tmp/log/storage) as a reasonable ignore surface for Ruby worktrees.
+    """
+    root = root.resolve()
+    sig = {
+        "wp_config": (root / "wp-config.php").is_file(),
+        "rails_app_rb": (root / "config" / "application.rb").is_file(),
+        "package_json": (root / "package.json").is_file(),
+        "gemfile": (root / "Gemfile").is_file(),
+    }
+    if sig["wp_config"]:
+        return TemplateDetection(
+            TEMPLATE_WORDPRESS, "Found wp-config.php (WordPress).", {"wp_config": True}
+        )
+    if sig["rails_app_rb"]:
+        return TemplateDetection(
+            TEMPLATE_RAILS, "Found config/application.rb (Rails).", {"rails_app_rb": True}
+        )
+    if sig["package_json"]:
+        return TemplateDetection(
+            TEMPLATE_NODE, "Found package.json (Node / JS toolchain).", {"package_json": True}
+        )
+    for path in ("pyproject.toml", "requirements.txt", "Pipfile", "setup.py"):
+        p = root / path
+        if p.is_file():
+            return TemplateDetection(
+                TEMPLATE_PYTHON, f"Found {path} (Python).", {f"has_{path}": True}
+            )
+    if sig["gemfile"]:
+        return TemplateDetection(
+            TEMPLATE_RAILS, "Found Gemfile without package.json (Ruby / likely Rails or Rack).", {"gemfile": True}
+        )
+    return TemplateDetection(
+        TEMPLATE_DEFAULT, "No strong stack markers; using generic MAT default template.", {}
+    )

--- a/scripts/adoption/manage-agents-sidecars.py
+++ b/scripts/adoption/manage-agents-sidecars.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+
+POINTER_START = "<!-- MAT_WORKFLOW_POINTER -->"
+POINTER_END = "<!-- /MAT_WORKFLOW_POINTER -->"
+INLINE_START = "<!-- MAT_WORKFLOW_INLINE_FALLBACK -->"
+INLINE_END = "<!-- /MAT_WORKFLOW_INLINE_FALLBACK -->"
+
+EXCLUDED_DIR_NAMES = {
+    ".git",
+    ".mat",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+}
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Apply non-destructive MAT sidecar pointers to AGENTS.md files."
+    )
+    parser.add_argument(
+        "--repo-root",
+        required=True,
+        help="Repository root containing product-owned AGENTS.md files.",
+    )
+    parser.add_argument(
+        "--inline-fallback",
+        "--merge-agents",
+        action="store_true",
+        dest="inline_fallback",
+        help="Write the explicit inline MAT fallback block instead of the pointer note.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report planned changes without writing files.",
+    )
+    parser.add_argument(
+        "--backup-dir",
+        help="Optional directory where pre-edit file backups are written.",
+    )
+    return parser
+
+
+def _repo_root(value: str) -> Path:
+    root = Path(value).expanduser().resolve()
+    if not root.is_dir():
+        raise ValueError(f"repository root does not exist: {root}")
+    return root
+
+
+def _sidecar_path(repo_root: Path) -> Path:
+    return repo_root / ".mat" / "AGENTS.mat.md"
+
+
+def _relative_sidecar_path(agents_path: Path, sidecar_path: Path) -> str:
+    rel = os.path.relpath(sidecar_path, start=agents_path.parent)
+    return Path(rel).as_posix()
+
+
+def _pointer_block(relative_sidecar: str) -> str:
+    return (
+        f"{POINTER_START}\n"
+        "## Multi-agent workflow (MAT)\n\n"
+        "This file stays product-owned. The canonical MAT reference lives in "
+        f"`{relative_sidecar}`.\n"
+        "Use the adoption helper's `--inline-fallback` flag only when you need the "
+        "explicit inline MAT section here.\n"
+        f"{POINTER_END}\n"
+    )
+
+
+def _inline_block(relative_sidecar: str) -> str:
+    return (
+        f"{INLINE_START}\n"
+        "## Multi-agent workflow (MAT)\n\n"
+        "This file stays product-owned. The canonical MAT reference lives in "
+        f"`{relative_sidecar}`.\n"
+        "This inline fallback is only present because the adoption helper was asked "
+        "to write it explicitly.\n"
+        f"{INLINE_END}\n"
+    )
+
+
+def _block_for_mode(relative_sidecar: str, inline_fallback: bool) -> str:
+    return _inline_block(relative_sidecar) if inline_fallback else _pointer_block(relative_sidecar)
+
+
+def _find_block_span(text: str, start_marker: str, end_marker: str) -> tuple[int, int] | None:
+    start = text.find(start_marker)
+    if start == -1:
+        return None
+    end = text.find(end_marker, start)
+    if end == -1:
+        return start, len(text)
+    return start, end + len(end_marker)
+
+
+def _replace_named_block(text: str, start_marker: str, end_marker: str, replacement: str) -> tuple[str, bool]:
+    span = _find_block_span(text, start_marker, end_marker)
+    if span is None:
+        return text, False
+
+    start, end = span
+    updated = text[:start].rstrip() + "\n\n" + replacement
+    if end < len(text):
+        trailing = text[end:]
+        if not trailing.startswith("\n"):
+            updated += "\n"
+        updated += trailing.lstrip("\n")
+    return updated, updated != text
+
+
+def _ensure_trailing_newline(text: str) -> str:
+    return text if text.endswith("\n") else text + "\n"
+
+
+def _append_block(text: str, block: str) -> str:
+    base = _ensure_trailing_newline(text).rstrip("\n")
+    return f"{base}\n\n{block}"
+
+
+def _apply_desired_block(text: str, desired_block: str, desired_start: str, desired_end: str, alternate_start: str, alternate_end: str) -> tuple[str, bool]:
+    updated, changed = _replace_named_block(text, desired_start, desired_end, desired_block)
+    if changed:
+        return _ensure_trailing_newline(updated), True
+
+    updated, changed = _replace_named_block(text, alternate_start, alternate_end, desired_block)
+    if changed:
+        return _ensure_trailing_newline(updated), True
+
+    if desired_start in text:
+        return text, False
+
+    return _append_block(text, desired_block), True
+
+
+def _iter_agents_files(repo_root: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in repo_root.rglob("AGENTS.md"):
+        if any(part in EXCLUDED_DIR_NAMES for part in path.relative_to(repo_root).parts):
+            continue
+        files.append(path)
+    return sorted(files)
+
+
+def _backup_file(file_path: Path, backup_dir: Path, repo_root: Path) -> Path:
+    relative = file_path.relative_to(repo_root)
+    backup_path = backup_dir / relative
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(file_path, backup_path)
+    return backup_path
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def _load_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _report(message: str) -> None:
+    print(f"manage-agents-sidecars: {message}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        repo_root = _repo_root(args.repo_root)
+    except ValueError as exc:
+        _report(str(exc))
+        return 2
+
+    sidecar_path = _sidecar_path(repo_root)
+    if not sidecar_path.is_file():
+        _report(f"missing canonical sidecar: {sidecar_path}")
+        return 2
+
+    agents_files = _iter_agents_files(repo_root)
+    if not agents_files:
+        _report("no AGENTS.md files found")
+        return 0
+
+    if args.backup_dir:
+        backup_dir = Path(args.backup_dir).expanduser().resolve()
+        if not args.dry_run:
+            backup_dir.mkdir(parents=True, exist_ok=True)
+    elif args.dry_run:
+        backup_dir = None
+    else:
+        backup_dir = Path(tempfile.mkdtemp(prefix="mat-agents-backup-"))
+
+    if args.dry_run:
+        _report("dry-run=yes")
+    else:
+        _report(f"backup-dir={backup_dir}")
+
+    changed_files: list[Path] = []
+    backed_up_files: list[Path] = []
+
+    for agents_path in agents_files:
+        current = _load_text(agents_path)
+        relative_sidecar = _relative_sidecar_path(agents_path, sidecar_path)
+        desired_block = _block_for_mode(relative_sidecar, args.inline_fallback)
+
+        updated, changed = _apply_desired_block(
+            current,
+            desired_block,
+            INLINE_START if args.inline_fallback else POINTER_START,
+            INLINE_END if args.inline_fallback else POINTER_END,
+            POINTER_START if args.inline_fallback else INLINE_START,
+            POINTER_END if args.inline_fallback else INLINE_END,
+        )
+
+        if not changed:
+            _report(f"unchanged {agents_path.relative_to(repo_root)}")
+            continue
+
+        changed_files.append(agents_path.relative_to(repo_root))
+        if args.dry_run:
+            _report(f"would update {agents_path.relative_to(repo_root)}")
+            continue
+
+        assert backup_dir is not None
+        backed_up = _backup_file(agents_path, backup_dir, repo_root)
+        backed_up_files.append(backed_up)
+        _write_text(agents_path, updated)
+        _report(f"updated {agents_path.relative_to(repo_root)}")
+
+    if changed_files:
+        _report("changed files:")
+        for rel in changed_files:
+            _report(f"  - {rel.as_posix()}")
+    else:
+        _report("no changes needed")
+
+    if not args.dry_run and backed_up_files:
+        _report("backups:")
+        for backup_path in backed_up_files:
+            _report(f"  - {backup_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/adoption/mat-footprint-v1.json
+++ b/scripts/adoption/mat-footprint-v1.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1.0.0",
+  "name": "mat-target-footprint-v1",
+  "description": "Target-repo MAT footprint contract for safe updater analysis and documentation bundles.",
+  "target_repo": {
+    "preserve_paths": [
+      "README.md",
+      "CHANGELOG.md",
+      "AGENTS.md",
+      "docs/current-plan.md",
+      "docs/long-run-state.md",
+      "build-result.md",
+      "verify-result.md"
+    ],
+    "protected_handoff_paths": [
+      "docs/current-plan.md",
+      "build-result.md",
+      "verify-result.md"
+    ],
+    "roles": [
+      "updater",
+      "watcher",
+      "scanner",
+      "analyzer",
+      "architect",
+      "generator",
+      "test",
+      "ci",
+      "reviewer",
+      "security",
+      "rollback"
+    ],
+    "docs": {
+      "documentation_index": "docs/update-mat/index.md",
+      "architecture_doc": "docs/update-mat/architecture-and-rollout.md",
+      "role_prompt_template": "docs/update-mat/role-prompt-templates.md",
+      "summary_schema": "docs/update-mat/advisor-task-session-summary.schema.json",
+      "summary_examples": "docs/update-mat/advisor-task-session-summary.examples.json"
+    },
+    "allow": {
+      "dry_run_default": true,
+      "apply_requires_approval": true,
+      "auto_commit": false,
+      "auto_pr": false,
+      "preserve_product_agents": true,
+      "sidecar_mode": "pointer-note-or-inline-fallback"
+    }
+  }
+}

--- a/scripts/adoption/mat-legacy-fingerprints.py
+++ b/scripts/adoption/mat-legacy-fingerprints.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""List or verify SHA256 content fingerprints for MAT legacy migration paths from git history."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_BOUNDARY = "aefa9f7^"
+_HEX64 = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def _git_text(
+    repo: Path,
+    args: list[str],
+    *,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_show_bytes(repo: Path, rev: str, rel_path: str) -> bytes | None:
+    completed = subprocess.run(
+        ["git", "show", f"{rev}:{rel_path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout
+
+
+def git_content_fingerprints_for_path(repo: Path, rel_path: str, boundary: str) -> list[str]:
+    """SHA256 of exact bytes at `rel_path` for each commit touching the path since `boundary`, unique sorted."""
+    log = _git_text(
+        repo,
+        ["log", boundary, "--format=%H", "--", rel_path],
+        check=False,
+    )
+    if log.returncode != 0:
+        raise RuntimeError((log.stderr or log.stdout or "git log failed").strip())
+    commits = [ln.strip() for ln in log.stdout.splitlines() if ln.strip()]
+    seen: set[str] = set()
+    out: list[str] = []
+    for rev in commits:
+        body = _git_show_bytes(repo, rev, rel_path)
+        if body is None:
+            continue
+        h = hashlib.sha256(body).hexdigest()
+        if h not in seen:
+            seen.add(h)
+            out.append(h)
+    out.sort()
+    return out
+
+
+def _normalize_path_seg(p: str) -> str:
+    n = p.replace("\\", "/").strip()
+    while n.startswith("./"):
+        n = n[2:]
+    return n
+
+
+def _load_manifest(manifest_path: Path) -> dict[str, Any]:
+    return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+
+def _load_manifest_entry(manifest_path: Path, rel_path: str) -> dict[str, Any] | None:
+    data = _load_manifest(manifest_path)
+    want = _normalize_path_seg(rel_path)
+    for entry in data.get("entries", []):
+        if isinstance(entry, dict) and _normalize_path_seg(str(entry.get("path", ""))) == want:
+            return entry
+    return None
+
+
+def _entry_boundary(entry: dict[str, Any], default: str) -> str:
+    prov = entry.get("fingerprint_provenance")
+    if isinstance(prov, dict):
+        boundary = prov.get("boundary")
+        if isinstance(boundary, str) and boundary.strip():
+            return boundary.strip()
+    return default
+
+
+def verify_manifest_fingerprints(
+    repo: Path,
+    manifest: Path,
+    rel_path: str,
+    boundary: str,
+    *,
+    strict: bool = False,
+) -> tuple[bool, str]:
+    """Return (ok, message). Set equality when manifest lists fingerprints; lenient when list is empty."""
+    git_fps = set(git_content_fingerprints_for_path(repo, rel_path, boundary))
+    entry = _load_manifest_entry(manifest, rel_path)
+    if entry is None:
+        return False, f"no manifest entry for path {rel_path!r}"
+    raw_fps = entry.get("fingerprints")
+    if not isinstance(raw_fps, list):
+        return False, "entry fingerprints is not a list"
+    man_fps = {str(x).lower() for x in raw_fps if isinstance(x, str) and _HEX64.match(str(x))}
+    # Non-hex entries are a manifest bug; validate_mat_legacy_migrations catches that separately.
+    handling = str(entry.get("handling", ""))
+    if not man_fps:
+        if git_fps and handling in {"backup_then_remove", "auto_remove"}:
+            return (
+                False,
+                f"manifest has no fingerprints but git history has {len(git_fps)} distinct blob(s); "
+                "add fingerprints or use warn_only",
+            )
+        if git_fps:
+            return True, f"no manifest fingerprints (git has {len(git_fps)} historical blob(s); not a drift check)"
+        return True, "no manifest fingerprints and no git history for path"
+
+    missing_in_manifest = git_fps - man_fps
+    if missing_in_manifest:
+        return False, f"git-derived blobs missing from manifest (add fingerprints): {sorted(missing_in_manifest)}"
+    extra_in_manifest = man_fps - git_fps
+    if extra_in_manifest and strict:
+        return False, f"manifest-only fingerprints not seen in git history (--strict): {sorted(extra_in_manifest)}"
+    if extra_in_manifest:
+        return (
+            True,
+            "ok: every git-derived blob is listed; manifest has extra documented fingerprints "
+            f"(not in git log for this path): {sorted(extra_in_manifest)}",
+        )
+    return True, "manifest fingerprints match git-derived union"
+
+
+def verify_all_manifest_fingerprints(
+    repo: Path,
+    manifest: Path,
+    *,
+    default_boundary: str = _DEFAULT_BOUNDARY,
+    strict: bool = False,
+) -> tuple[bool, list[tuple[str, bool, str]]]:
+    """Verify every manifest entry with non-empty fingerprints. Returns (all_ok, per-entry results)."""
+    data = _load_manifest(manifest)
+    entries = data.get("entries", [])
+    if not isinstance(entries, list):
+        raise ValueError("manifest missing entries array")
+
+    results: list[tuple[str, bool, str]] = []
+    all_ok = True
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        raw_fps = entry.get("fingerprints")
+        if not isinstance(raw_fps, list) or not raw_fps:
+            continue
+        rel = _normalize_path_seg(str(entry.get("path", "")))
+        if not rel:
+            continue
+        boundary = _entry_boundary(entry, default_boundary)
+        ok, msg = verify_manifest_fingerprints(
+            repo,
+            manifest,
+            rel,
+            boundary,
+            strict=strict,
+        )
+        results.append((rel, ok, msg))
+        if not ok:
+            all_ok = False
+    return all_ok, results
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Print sorted SHA256 fingerprints of every distinct file body for --path across git history "
+            f"(default boundary {_DEFAULT_BOUNDARY!r}: last revision before mat-* rename slice), "
+            "or --verify / --verify-all against mat-legacy-migrations-v1.json."
+        ),
+    )
+    p.add_argument("--repo", default=".", type=Path, help="Git repository root (default: cwd).")
+    p.add_argument(
+        "--path",
+        help="Repository-relative path (posix-style). Optional when --verify-all is set.",
+    )
+    p.add_argument(
+        "--boundary",
+        default=_DEFAULT_BOUNDARY,
+        help=f"Passed to `git log <boundary> -- <path>` (default: {_DEFAULT_BOUNDARY!r}).",
+    )
+    p.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path(__file__).with_name("mat-legacy-migrations-v1.json"),
+        help="Legacy migrations manifest (for --verify / --verify-all).",
+    )
+    p.add_argument(
+        "--verify",
+        action="store_true",
+        help="Ensure every git-derived blob for --path is listed in the manifest (default allows manifest-only extras such as test stubs).",
+    )
+    p.add_argument(
+        "--verify-all",
+        action="store_true",
+        help="Verify every manifest entry with non-empty fingerprints (per-entry boundary from fingerprint_provenance when set).",
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="With --verify or --verify-all, also fail when the manifest lists fingerprints not found in git history for the path.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    repo = args.repo.expanduser().resolve()
+    manifest = args.manifest.expanduser().resolve()
+
+    if args.verify_all:
+        try:
+            all_ok, results = verify_all_manifest_fingerprints(
+                repo,
+                manifest,
+                default_boundary=args.boundary,
+                strict=args.strict,
+            )
+        except Exception as exc:
+            print(f"mat-legacy-fingerprints: {exc}", file=sys.stderr)
+            return 1
+        if not results:
+            print("verify-all: no fingerprinted manifest entries")
+            return 0
+        failed = [(rel, msg) for rel, ok, msg in results if not ok]
+        passed = len(results) - len(failed)
+        print(f"verify-all: {passed}/{len(results)} entries passed")
+        for rel, ok, msg in results:
+            status = "PASS" if ok else "FAIL"
+            print(f"  [{status}] {rel}: {msg}")
+        return 0 if all_ok else 2
+
+    if not args.path:
+        print("mat-legacy-fingerprints: --path is required unless --verify-all is set", file=sys.stderr)
+        return 1
+
+    rel = _normalize_path_seg(args.path)
+    try:
+        if args.verify:
+            entry = _load_manifest_entry(manifest, rel)
+            boundary = _entry_boundary(entry, args.boundary) if entry else args.boundary
+            ok, msg = verify_manifest_fingerprints(
+                repo,
+                manifest,
+                rel,
+                boundary,
+                strict=args.strict,
+            )
+            print(msg)
+            return 0 if ok else 2
+        fps = git_content_fingerprints_for_path(repo, rel, args.boundary)
+        for h in fps:
+            print(h)
+        return 0
+    except Exception as exc:
+        print(f"mat-legacy-fingerprints: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/adoption/mat-legacy-migrations-v1.json
+++ b/scripts/adoption/mat-legacy-migrations-v1.json
@@ -1,0 +1,276 @@
+{
+  "schema_version": "1.0.0",
+  "description": "Obsolete MAT-managed paths in adopted repos \u2014 successor surfaces and safe handling modes.",
+  "handling_modes": {
+    "auto_remove": "Remove only when file bytes match a listed fingerprint (sha256 hex of exact content). Never removes without a match.",
+    "backup_then_remove": "Fingerprint match: copy under legacy quarantine then remove. Customized content: copy to quarantine prefixed as customized-* and leave the original in place.",
+    "warn_only": "Never delete; append decision to audit JSONL and print stderr when the path exists."
+  },
+  "entries": [
+    {
+      "path": ".cursor/commands/plan_w_team.md",
+      "successor": ".cursor/commands/mat-plan-team.md",
+      "handling": "backup_then_remove",
+      "fingerprints": [
+        "033b1a324f5881a895ba5ff3e0f6997546ac4941b052c0eef2f631ff3ebdb89a",
+        "0d42b0d5117042794aa5e94b5f0c1bb989ba51226f209eccd825b1943733ec8c",
+        "1166dd449fc8f686b7c961d83406b1cde11f94c35ddb274bfcc45ce599c2d6d5",
+        "12c95824a4d3fc3a5ca6cae25e46165b894ab33a16d83672a4f37a311e8c1860",
+        "1416ac9af144c140f3d82d7d3d4c24573906ee0c3669e78d6f4984a406fdc12a",
+        "16c74bbe7ca9de8cbfd2bbff0ff463456f0b551c8fdf223663160b100b372ec8",
+        "1b96288aacc3bd9e3d9f3387564717e778948d36a91e6ba91fbcf8d803914c60",
+        "248162d789f7a34b4167df8be80dafccb5f5298d689132a6ace84eb045afef95",
+        "27ea478d6523600d15885726544a42b2bf8543eefc298b61e646c395c0d1fcc9",
+        "2a7e32052c247f1df1f87710135c0d7210456a53fbe8c38e0561d3b50998cd1d",
+        "2c5a1aaf04355ff3f0d8bb9f25d5b023ecceabd5e32f27d141ab978cd529d7fa",
+        "3f9f82fd58c460be60ada705ac103c25ddb9f3891d7611cbd534ce55975192ea",
+        "43f89be94f785b1f33901b7be6764a2ac4fd149734d628e9e8992d263016e235",
+        "4a67dea2851863df775c3be36adf99381116c2c0b41fe1f2a956f36bd272ebbb",
+        "4b2013b374d0217f045d07161277b66bd22f80d12c8ab805ce4be960f0b7dba2",
+        "4c1e8195a5ab9c1b7c786e1c8c3aca5aa99210deda160fb37e2e8505921a689d",
+        "4d84d3d392e4c9a184390be78c395e832f8ae482d391ce592a9d0e58c1b24cf2",
+        "50fb14abff9920f801be3752fa5f9b92275b2be222c5b5f8f382ec38febeb04f",
+        "614f8f7ae6d22615b2f322384ab4339f35a46ae378d6903da6b31290ee91ecfd",
+        "6f312cc6c2bceb3a1883a66edf4b7b901d6512bc6ef3f8e1b0f9e8c97b6dd7a3",
+        "7331eb7ad72b9f6a82e876ce939af0b5d4ca3926498238a01d6162f0ae7acdb5",
+        "8b4c9cd51bee7402a31677bc2858d52656ebbb67e2651bb90abdbed2f19d988b",
+        "95844405b88031c445f2488fa9dc43247304266f80af7bc650d13e2d4c3e4bc4",
+        "ab6204ac3d28539ae7a4d8a75ff9b9fd83721c70c4075790d5e981323f3f3a51",
+        "bd688de1956bfa875f6cc5054789622f7963429f3057ce78ab36c69a02bf3555",
+        "c73dd0b63b110b6d8a79c232dda8d0de0cffc32f9c325e270ef04bf833d3cddd",
+        "c7b56d3ebf9c3b4a6bd85b0bbac871cbfc7811c9fd4f50215bf2c8504935e260",
+        "cc58d21ca442ae7219e901b897d723063fbd0e2ecef0824152829cfb407740e7",
+        "dc80301ec9b8c696a4090425b327abe022a3daae84c50040289cb56e1338886e",
+        "eaca0ca6bf606367c2b0c48f893db67727d0e8e5350798d4815e6a2802b4dc15"
+      ],
+      "fingerprint_provenance": {
+        "boundary": "aefa9f7^",
+        "source": "git_log_union_plus_stub",
+        "generated_at": "2026-06-22",
+        "note": "Union of every distinct blob from git log aefa9f7^ -- .cursor/commands/plan_w_team.md in this MAT repo, plus regression stub 2c5a1aaf04355ff3f0d8bb9f25d5b023ecceabd5e32f27d141ab978cd529d7fa from tests/test_mat_legacy_integration.py."
+      },
+      "notes": "Historical underscore-named stub superseded by mat-plan-team.md. Fingerprints are SHA256 of exact bytes ever committed to this MAT repo for this path on `git log aefa9f7^ -- <path>` (pre mat-* rename), plus the documented test/stub bytes for plan_w_team."
+    },
+    {
+      "path": ".cursor/commands/plan-team.md",
+      "successor": ".cursor/commands/mat-plan-team.md",
+      "handling": "warn_only",
+      "fingerprints": [],
+      "notes": "Possible alternate legacy filename; no canonical fingerprint \u2014 operator review only."
+    },
+    {
+      "path": ".cursor/commands/build.md",
+      "successor": ".cursor/commands/mat-build.md",
+      "handling": "backup_then_remove",
+      "fingerprints": [
+        "0504420b8f5f362c2934c186a1913ef1df1ddb297f173e22ac2eb4d25f08b606",
+        "08941bcb59bb1434fa93919f6f1bfebf91be50a003d94d484fd05db7b2cfd9ef",
+        "393a69167bad6168ce8542c91568a77f3950082ed40a4da30a93a29d6727472c",
+        "521a1b138cea669a9947b8d836e336b3fd1eff2950e38b47d858b8fa06fcafe9",
+        "6ceb85b4ce8bcdace8126d714d31d9a86fc39129980ba03b916e60649b9985df",
+        "a3aeff7c100528662d375d0272cb79ea116d8221f275f5892aaa93848c3c3285",
+        "b0bdf0e30355e5b78ed6bcbbfff7f5875ca0b070740159861b07fde9968642c6",
+        "b68b87284036c6a5e0b04e16845272fea09a45813033c60c00878d1b26d0b82b",
+        "b80ef537d660987de7c838dfbe2c524ad7518e7aab2634a2f4dc224d177638fc",
+        "bc300e7c8744d12636f98cc2cdd6cae9dfee8f071cb3787e04fc098819c6b0ab",
+        "bc4e4557bd75a7861094a4202785819d64284fd6194b86a3e39761e7b044a5ea",
+        "c13f27dad57a1c7eb09f54a647801b6a44ced39bdf436c8991bbe64ecc7116b4",
+        "cec521321deda889712adaf0c290c77495bc76af70bc28e8f523c487910de142",
+        "cf20f60e0d85ff5e15dc84a8f09a40302cdc91b14fdb7af63d2cf737d51578c1",
+        "df1f0bc4f36a8f33056fb14a0004b823fb9b98778e470dc6bab6ba2c3c32e812",
+        "e18a15b2f61527cb23aa6472d1f3aedf9449a01fa1279ea4f4fafac8313e8258"
+      ],
+      "fingerprint_provenance": {
+        "boundary": "aefa9f7^",
+        "source": "git_log_union",
+        "generated_at": "2026-06-22",
+        "note": "Union of every distinct blob from git log aefa9f7^ -- .cursor/commands/build.md in this MAT repo (pre mat-* rename)."
+      },
+      "notes": "Legacy build command; superseded by mat-build.md. Fingerprints are SHA256 of exact bytes ever committed to this MAT repo for this path on `git log aefa9f7^ -- <path>` (pre mat-* rename)."
+    },
+    {
+      "path": ".cursor/commands/review.md",
+      "successor": ".cursor/commands/mat-review.md",
+      "handling": "backup_then_remove",
+      "fingerprints": [
+        "01e13a1674e43884b915528cdc730938032f09c76211ecc6e282faa5e4641835",
+        "1a5a9fce1246abf7bf39abe3b56e145ccabeb82bb0dd48c349e2eadc295af17d",
+        "20db40a8e160af8217d5b3734454bc6607566f0d3b1bcd7476b94dce1b04ea44",
+        "29ed024ff35c92295b75aa2085dd7e8fa7f16c556f50920666dded2d91f0650e",
+        "34ee206a32a5e9611b6cd65c9d6dcbdabf55fa2a22a455017c3091f6ac4694aa",
+        "3a6ec0ee2ef81f035fa4c0f6f5f2ec37620e7596546d72fef17f18173bbb7074",
+        "43a4e124beb166b84fd30a69eab39483b9c3458b36004916cc4fbeb5e2e68dd4",
+        "62437b0bae6f8be12420797546fbccfce7c0e7c0e591c98e26497a1313ca16f3",
+        "8347a53633f88b42e3b33978e78aa6c7be5c225550abed57d4e9d50dd7c5bbed",
+        "94c60d9fe12ddedb763971a3cf1fbbd0ad08301333b463535deea8e90dfd87a7",
+        "9bd694dfc33904767fdddf57a9f733da4f7c743d6ce86feaee771c78145b70ea",
+        "a87f202cda6bfa2b4c9eae8ef5ef07404f3737c7ef6d0087751b6d046d1e4bda",
+        "b7d187f8d631400d0e0fb1f3f776947de45e44066e517eb399032d1257cb0549",
+        "d53a6de4e7dcd6ec766ca57c23311e50db09ceeedd4abaf91ebcb6af96153352",
+        "df7fd2a6d89df18035e544c18c2389a522652bb629f1ca7eda4557c7c329adf7",
+        "f33a7fc0d747e07aa5e683b2905312b23904bdeabb81d0ab8a02353ba36ccc4c"
+      ],
+      "fingerprint_provenance": {
+        "boundary": "aefa9f7^",
+        "source": "git_log_union",
+        "generated_at": "2026-06-22",
+        "note": "Union of every distinct blob from git log aefa9f7^ -- .cursor/commands/review.md in this MAT repo (pre mat-* rename)."
+      },
+      "notes": "Legacy review command; superseded by mat-review.md. Fingerprints are SHA256 of exact bytes ever committed to this MAT repo for this path on `git log aefa9f7^ -- <path>` (pre mat-* rename)."
+    },
+    {
+      "path": ".cursor/commands/long-run.md",
+      "successor": ".cursor/commands/mat-long-run.md",
+      "handling": "backup_then_remove",
+      "fingerprints": [
+        "06d6495ed4eba9401e54056f89d9d4b4190c06dce6be061c15836b00737a4757",
+        "57dcd3cc8e5348da44d469fef8ebfb0a1a490df9d710a3658d0a108353088aca",
+        "718709d374780abf292dfc8f31b6aabbc1844342de63972d20325d59b0d718bb",
+        "7f455e8cd3c1a33e60c0f1287398613c0986521a4f4f349e7bcaf21600498c45",
+        "8af78e75cbddfc562700d05cb4b4ba072d90622c9318005090e659eac52ca64e",
+        "c5d17998ecffc5f85fcce6bf20b88b073ccd54ebfc19d6731e7d8da9ac398c6e",
+        "d31fa96ffde5ba5c2efa043ddc7855da258d1b22763253107dbecbc9ed081d99",
+        "ff967c59ea3373cd37f03e57efcd1713a68c134e7aa67aa42b024620a548725e"
+      ],
+      "fingerprint_provenance": {
+        "boundary": "aefa9f7^",
+        "source": "git_log_union",
+        "generated_at": "2026-06-22",
+        "note": "Union of every distinct blob from git log aefa9f7^ -- .cursor/commands/long-run.md in this MAT repo (pre mat-* rename)."
+      },
+      "notes": "Legacy long-run command; superseded by mat-long-run.md. Fingerprints are SHA256 of exact bytes ever committed to this MAT repo for this path on `git log aefa9f7^ -- <path>` (pre mat-* rename)."
+    },
+    {
+      "path": ".cursor/commands/plan.md",
+      "successor": ".cursor/commands/mat-plan.md",
+      "handling": "backup_then_remove",
+      "fingerprints": [
+        "3862fbb29eeeab37d5e9dc058415c15f7109def7c193de2317681bff1d5b24ee",
+        "57b16b096096b8721fc67f68ba4040ba6d9d97dbb8eeb686819cfec60901cd8e",
+        "65961b749146efc3341ffeb59737fda903b318e4d09c47f20d1e71d878506f3b"
+      ],
+      "fingerprint_provenance": {
+        "boundary": "aefa9f7^",
+        "source": "git_log_union",
+        "generated_at": "2026-06-22",
+        "note": "Union of every distinct blob from git log aefa9f7^ -- .cursor/commands/plan.md in this MAT repo (pre mat-* rename)."
+      },
+      "notes": "Legacy plan command; superseded by mat-plan.md. Fingerprints are SHA256 of exact bytes ever committed to this MAT repo for this path on `git log aefa9f7^ -- <path>` (pre mat-* rename)."
+    },
+    {
+      "path": ".cursor/commands/plan_onboarding.md",
+      "successor": ".cursor/commands/mat-plan-onboarding.md",
+      "handling": "backup_then_remove",
+      "fingerprints": [
+        "0fc9aeeff1e9d0714081ce1e04035a7a45e377366e5b1c49d7135a7b899c2437",
+        "2c7df7bbe192d483b707162325e4d882ebf7750ff4f27b643785741f00751841",
+        "59741acfcd5b6374563e410d8ae91e338193728bf2fc28ccdf6acf9ec4695eb7",
+        "c1605e0ba03dc5aebfa3c575278a3e2c6e6996d582ef76fee1f1d28163c8692b",
+        "f7ebe4caed956e4509f26e5c356b2865bc8a1b569f540e7d37354cd8bae00b81"
+      ],
+      "fingerprint_provenance": {
+        "boundary": "aefa9f7^",
+        "source": "git_log_union",
+        "generated_at": "2026-06-22",
+        "note": "Union of every distinct blob from git log aefa9f7^ -- .cursor/commands/plan_onboarding.md in this MAT repo (pre mat-* rename)."
+      },
+      "notes": "Legacy plan-onboarding command; superseded by mat-plan-onboarding.md. Fingerprints are SHA256 of exact bytes ever committed to this MAT repo for this path on `git log aefa9f7^ -- <path>` (pre mat-* rename)."
+    },
+    {
+      "path": ".cursor/commands/doctor.md",
+      "successor": ".cursor/commands/mat-doctor.md",
+      "handling": "backup_then_remove",
+      "fingerprints": [
+        "7502789626102f26ab0527092cce66c92a450de0f6930cc8250cfe4ff647382b"
+      ],
+      "fingerprint_provenance": {
+        "boundary": "aefa9f7^",
+        "source": "git_log_union",
+        "generated_at": "2026-06-22",
+        "note": "Union of every distinct blob from git log aefa9f7^ -- .cursor/commands/doctor.md in this MAT repo (pre mat-* rename)."
+      },
+      "notes": "Legacy doctor command; superseded by mat-doctor.md. Fingerprints are SHA256 of exact bytes ever committed to this MAT repo for this path on `git log aefa9f7^ -- <path>` (pre mat-* rename)."
+    },
+    {
+      "path": ".cursor/commands/lite.md",
+      "successor": ".cursor/commands/mat-lite.md",
+      "handling": "backup_then_remove",
+      "fingerprints": [
+        "3a2128c978375e5398c3ea1977932e20b6e124ca357e027b235d19798692c1db",
+        "5cb0c0e3e5ce67b50faa80e989df69e83bea04827980ecbafd4783e931eff007"
+      ],
+      "fingerprint_provenance": {
+        "boundary": "aefa9f7^",
+        "source": "git_log_union",
+        "generated_at": "2026-06-22",
+        "note": "Union of every distinct blob from git log aefa9f7^ -- .cursor/commands/lite.md in this MAT repo (pre mat-* rename)."
+      },
+      "notes": "Legacy lite command; superseded by mat-lite.md. Fingerprints are SHA256 of exact bytes ever committed to this MAT repo for this path on `git log aefa9f7^ -- <path>` (pre mat-* rename)."
+    },
+    {
+      "path": ".cursor/commands/sprint.md",
+      "successor": ".cursor/commands/mat-sprint.md",
+      "handling": "backup_then_remove",
+      "fingerprints": [
+        "4d001532aff86346093567b71f7f92aa2dd53386504d0a17d204b05dfddd8325",
+        "6b06e71a378130eecb04ea545b43503a5b6a633009300c238234116ebf272658",
+        "85953497b86e88f203fee1cf98e5139a594c472f3e5ce5270fa607c37d80552f",
+        "990747f3e215f8f52dc8fbf6944267f126e481fb53ff3240eabe6f58d9c8e906",
+        "ea82a856a5900eaf920f0e5d1ed1a1c45ba6cf37c6ea548318de74d0d6b0ac20"
+      ],
+      "fingerprint_provenance": {
+        "boundary": "aefa9f7^",
+        "source": "git_log_union",
+        "generated_at": "2026-06-22",
+        "note": "Union of every distinct blob from git log aefa9f7^ -- .cursor/commands/sprint.md in this MAT repo (pre mat-* rename)."
+      },
+      "notes": "Legacy sprint command; superseded by mat-sprint.md. Fingerprints are SHA256 of exact bytes ever committed to this MAT repo for this path on `git log aefa9f7^ -- <path>` (pre mat-* rename)."
+    },
+    {
+      "path": ".cursor/commands/subagents_spawn.md",
+      "successor": ".cursor/commands/mat-subagents-spawn.md",
+      "handling": "backup_then_remove",
+      "fingerprints": [
+        "6aaaaf7025407f0f109e2ad0781d35523eff91f348032a3389fa2d80ea106d37"
+      ],
+      "fingerprint_provenance": {
+        "boundary": "aefa9f7^",
+        "source": "git_log_union",
+        "generated_at": "2026-06-22",
+        "note": "Union of every distinct blob from git log aefa9f7^ -- .cursor/commands/subagents_spawn.md in this MAT repo (pre mat-* rename)."
+      },
+      "notes": "Legacy subagents-spawn command; superseded by mat-subagents-spawn.md. Fingerprints are SHA256 of exact bytes ever committed to this MAT repo for this path on `git log aefa9f7^ -- <path>` (pre mat-* rename)."
+    },
+    {
+      "path": ".cursor/commands/update_mat.md",
+      "successor": ".cursor/commands/mat-update-mat.md",
+      "handling": "backup_then_remove",
+      "fingerprints": [
+        "2c7ec8254715a09bbb8f9cb520a978ed4fd0f9bdc97bb1c987f094c11acff914",
+        "c47e921df22bd7e757a98d75f6bf5eca39d98c4a0e8dfae09b787ffaa6c9aa45"
+      ],
+      "fingerprint_provenance": {
+        "boundary": "aefa9f7^",
+        "source": "git_log_union",
+        "generated_at": "2026-06-22",
+        "note": "Union of every distinct blob from git log aefa9f7^ -- .cursor/commands/update_mat.md in this MAT repo (pre mat-* rename)."
+      },
+      "notes": "Legacy update-mat command; superseded by mat-update-mat.md. Fingerprints are SHA256 of exact bytes ever committed to this MAT repo for this path on `git log aefa9f7^ -- <path>` (pre mat-* rename)."
+    },
+    {
+      "path": ".cursor/commands/check_worktrees.md",
+      "successor": ".cursor/commands/mat-wt-check.md",
+      "handling": "backup_then_remove",
+      "fingerprints": [
+        "77d2790270a4ad4d8310a835ad6ebb19d3dcd467058fa8dfffc8f5302ce943e4"
+      ],
+      "fingerprint_provenance": {
+        "boundary": "aefa9f7^",
+        "source": "git_log_union",
+        "generated_at": "2026-06-22",
+        "note": "Union of every distinct blob from git log aefa9f7^ -- .cursor/commands/check_worktrees.md in this MAT repo (pre mat-* rename)."
+      },
+      "notes": "Legacy worktree-check command; superseded by mat-wt-check.md. Fingerprints are SHA256 of exact bytes ever committed to this MAT repo for this path on `git log aefa9f7^ -- <path>` (pre mat-* rename)."
+    }
+  ]
+}

--- a/scripts/adoption/migrate-long-run-state.py
+++ b/scripts/adoption/migrate-long-run-state.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Restore a mission-level execution_mode in docs/long-run-state.md when safely possible."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+MISSION_SECTION_RE = re.compile(
+    r"^##\s+Mission\s*$\n(?P<body>.*?)(?=^##\s+|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+VALID_EXECUTION_MODE_RE = re.compile(
+    r"^\s*-\s+\*\*execution_mode:\*\*\s+`(short-run|long-run)`\s*$",
+    re.MULTILINE,
+)
+ANY_EXECUTION_MODE_RE = re.compile(r"\*\*execution_mode:\*\*")
+
+REMEDIATION = """migrate-long-run-state: docs/long-run-state.md needs a mission-level execution mode.
+Add this bullet under `## Mission`:
+  - **execution_mode:** `long-run`
+See `docs/getting-started-existing-projects.md` for the non-interactive adoption path.
+"""
+
+
+def extract_mission_section(text: str) -> str | None:
+    match = MISSION_SECTION_RE.search(text)
+    if not match:
+        return None
+    return match.group("body")
+
+
+def needs_migration(text: str) -> bool:
+    mission_section = extract_mission_section(text)
+    if mission_section is None:
+        return True
+    return VALID_EXECUTION_MODE_RE.search(mission_section) is None
+
+
+def migrate(text: str) -> str | None:
+    match = MISSION_SECTION_RE.search(text)
+    if not match:
+        return None
+
+    mission_section = match.group("body")
+    if VALID_EXECUTION_MODE_RE.search(mission_section):
+        return None
+    if ANY_EXECUTION_MODE_RE.search(mission_section):
+        return None
+
+    insertion = match.start("body")
+    return text[:insertion] + "- **execution_mode:** `long-run`\n" + text[insertion:]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", type=Path, help="Path to docs/long-run-state.md")
+    args = parser.parse_args()
+
+    path = args.path.resolve()
+    if not path.exists():
+        print(f"migrate-long-run-state: missing file {path}", file=sys.stderr)
+        return 2
+
+    text = path.read_text(encoding="utf-8")
+    if not needs_migration(text):
+        print(f"migrate-long-run-state: already valid: {path}")
+        return 0
+
+    new_text = migrate(text)
+    if new_text is None:
+        print(REMEDIATION, file=sys.stderr)
+        return 2
+
+    path.write_text(new_text, encoding="utf-8")
+    print(f"migrate-long-run-state: wrote mission execution_mode into {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/adoption/update-mat.py
+++ b/scripts/adoption/update-mat.py
@@ -1,0 +1,841 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from apply_mat_legacy_cleanup import apply_legacy_cleanup  # noqa: E402
+from update_mat_contracts import (  # noqa: E402
+    build_compatibility_snapshot,
+    load_footprint_manifest,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = Path(__file__).with_name("adoption-layout-v1.json")
+DEFAULT_FOOTPRINT = Path(__file__).with_name("mat-footprint-v1.json")
+AGENTS_HELPER = Path(__file__).with_name("manage-agents-sidecars.py")
+DEFAULT_AUDIT_DIR = "artifacts/update-mat"
+
+
+@dataclass(slots=True)
+class MappingItem:
+    kind: str
+    source: str | None
+    target: str
+    managed: str
+
+
+@dataclass(slots=True)
+class FileDiff:
+    source: str
+    target: str
+    change_type: str
+    source_sha256: str | None
+    target_sha256: str | None
+    preview: str | None = None
+
+
+@dataclass(slots=True)
+class UpdatePlan:
+    upstream_source: str
+    upstream_ref: str
+    upstream_commit: str
+    target_root: str
+    target_baseline: str | None
+    dry_run: bool
+    stage_mode: str
+    changed_files: list[FileDiff]
+    agents_reconciliation_needed: bool
+    agents_preview: str
+    conflicts: list[str]
+    preserved_paths: list[str]
+    rollback_hint: str
+    compatibility_snapshot: dict[str, Any]
+    staging_path: str | None = None
+    staging_branch: str | None = None
+    backup_dir: str | None = None
+    legacy_cleanup_preview: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _legacy_cleanup_preview_payload(target_root: Path, audit_dir_rel: str) -> list[dict[str, Any]]:
+    """Run legacy migration engine against the target tree without mutations (no JSONL/quarantine writes)."""
+    manifest = target_root / "scripts" / "adoption" / "mat-legacy-migrations-v1.json"
+    footprint = target_root / "scripts" / "adoption" / "mat-footprint-v1.json"
+    script = target_root / "scripts" / "adoption" / "apply_mat_legacy_cleanup.py"
+    if not manifest.is_file() or not footprint.is_file() or not script.is_file():
+        return []
+    decisions = apply_legacy_cleanup(
+        repo_root=target_root,
+        migration_manifest_path=manifest,
+        footprint_manifest_path=footprint,
+        audit_dir_rel=audit_dir_rel,
+        dry_run=True,
+    )
+    return [
+        {
+            "path": d.path,
+            "action": d.action,
+            "reason": d.reason,
+            "successor": d.successor,
+            "handling": d.handling,
+            "sha256": d.sha256,
+            "dry_run": d.dry_run,
+        }
+        for d in decisions
+    ]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Safely preview or stage MAT updates for an adopted repository.")
+    parser.add_argument("--source", "--source-root", dest="source", required=True, help="Upstream MAT source repository path or Git URL.")
+    parser.add_argument("--ref", default="HEAD", help="Upstream ref to compare against (default: HEAD).")
+    parser.add_argument("--target", "--repo-root", dest="target", default=".", help="Target adopted repository root (default: current directory).")
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST), help="Path to the MAT layout manifest.")
+    parser.add_argument("--footprint", default=str(DEFAULT_FOOTPRINT), help="Path to the target-repo MAT footprint manifest.")
+    parser.add_argument("--apply", action="store_true", help="Stage the update in an isolated worktree before stopping for review.")
+    parser.add_argument("--stage-mode", choices=("worktree", "branch"), default="worktree", help="How to stage apply-mode changes.")
+    parser.add_argument("--plan-file", help="Existing dry-run plan file to validate before applying.")
+    parser.add_argument("--approved", action="store_true", help="Explicitly approve apply-mode staging and review handoff.")
+    parser.add_argument("--show-patch", action="store_true", help="Print the patch preview and write a patch file.")
+    parser.add_argument("--backup-dir", help="Optional backup directory for apply-mode file snapshots.")
+    parser.add_argument("--inline-fallback", action="store_true", help="Run the AGENTS helper in inline-fallback mode while staging.")
+    parser.add_argument("--audit-dir", default=DEFAULT_AUDIT_DIR, help="Directory for audit JSONL output relative to the target repo.")
+    return parser
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _repo_root(value: str) -> Path:
+    return Path(value).expanduser().resolve()
+
+
+def _git(args: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, check=check, capture_output=True, text=True)
+
+
+def _git_commit(path: Path) -> str | None:
+    completed = _git(["rev-parse", "HEAD"], cwd=path, check=False)
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip()
+
+
+def _git_status_clean(path: Path) -> bool:
+    completed = _git(["status", "--porcelain"], cwd=path, check=False)
+    return completed.returncode == 0 and not completed.stdout.strip()
+
+
+def _is_git_repo(path: Path) -> bool:
+    return _git(["rev-parse", "--is-inside-work-tree"], cwd=path, check=False).returncode == 0
+
+
+def _load_layout_manifest(manifest_path: Path) -> dict:
+    layout = _load_json(manifest_path)
+    if layout.get("schema_version") not in {"1", "1.0.0"}:
+        raise ValueError(f"unsupported manifest schema version: {layout.get('schema_version')}")
+    return layout
+
+
+def _load_footprint_manifest(manifest_path: Path) -> dict:
+    return load_footprint_manifest(manifest_path)
+
+
+def _layout_mappings(layout: dict) -> list[MappingItem]:
+    items: list[MappingItem] = []
+
+    items.append(MappingItem(kind="generated", source=None, target=".mat/README.md", managed="mat-readme"))
+    for item in layout.get("mat_docs", []):
+        items.append(MappingItem(kind="file", source=item["src"], target=item["dest"], managed="mat-doc"))
+    for rel in layout.get("mat_tests", []):
+        items.append(MappingItem(kind="file", source=rel, target=f".mat/tests/{Path(rel).name}", managed="mat-test"))
+    items.append(MappingItem(kind="file", source=layout.get("source_agents_for_mat", "AGENTS.md"), target=layout["mat_sidecar"]["agents_mat"], managed="mat-agents"))
+    items.append(MappingItem(kind="file", source=layout.get("source_readme_for_vendor", "README.md"), target=layout["mat_sidecar"]["vendor_readme_mat"], managed="vendor-readme"))
+    for rel in layout.get("cursor_copy", {}).get("files", []):
+        items.append(MappingItem(kind="file", source=rel, target=rel, managed="cursor-file"))
+    for rel_dir in layout.get("cursor_copy", {}).get("dir_contents", []):
+        items.append(MappingItem(kind="dir", source=rel_dir, target=rel_dir, managed="cursor-dir"))
+    for rel in layout.get("root_scripts_copy", []):
+        items.append(MappingItem(kind="file", source=rel, target=rel, managed="root-script"))
+    return items
+
+
+def _repo_paths_from_dir(root: Path) -> dict[str, Path]:
+    files: dict[str, Path] = {}
+    if not root.exists():
+        return files
+    for current in root.rglob("*"):
+        rel = current.relative_to(root).as_posix()
+        if "__pycache__" in rel or rel.endswith(".pyc") or rel.endswith(".log") or "continual-learning" in rel:
+            continue
+        if current.is_file():
+            files[current.relative_to(root).as_posix()] = current
+    return files
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _render_mat_readme() -> str:
+    return """
+# `.mat/` — Multi-agent workflow (MAT) sidecar
+
+This directory holds **MAT-packaged** material for this repository: reference documentation and workflow contract tests copied from the MAT source repo. It keeps product documentation at the repo root separate from workflow manuals.
+
+- **`.mat/docs/`** — packaged workflow documentation (components, getting started, MAO protocol, etc.).
+- **`.mat/tests/`** — workflow contract tests (`unittest`); run with `python3 -m unittest discover -s .mat/tests -p 'test_*.py' -v`.
+- **`.mat/AGENTS.mat.md`** — full MAT operator reference from the source `AGENTS.md`.
+- **`.mat/vendor/README-MAT.md`** — optional attribution copy of the MAT source `README.md`.
+
+Entrypoints at repo root: **`scripts/phase1-verify.sh`**, **`.cursor/`** (hooks, commands, agents).
+
+`phase1-verify.sh` treats this sidecar as present when this file exists: it may skip missing `build-result.md` / `verify-result.md`, skip closeout matrix checks until `artifacts/agent-traces/comparison.json` exists, run **`unittest`** under **`.mat/tests/`**, and skip Bun smoke when `apps/server` is absent.
+
+For product narrative, use the root **`README.md`** and your application docs — not this tree.
+""".strip() + "\n"
+
+
+def _source_tree(source: str, ref: str) -> tuple[Path, str]:
+    source_path = Path(source).expanduser().resolve()
+    if source_path.exists() and source_path.is_dir() and ref in {"", "HEAD"}:
+        return source_path, _git_commit(source_path) or "unknown"
+
+    clone_root = Path(tempfile.mkdtemp(prefix="mat-update-source-"))
+    clone_dir = clone_root / "source"
+    completed = _git(["clone", "--no-tags", "--quiet", source, str(clone_dir)], cwd=REPO_ROOT, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr or completed.stdout or "failed to clone source repository")
+    checkout = _git(["checkout", "--quiet", ref], cwd=clone_dir, check=False)
+    if checkout.returncode != 0:
+        raise RuntimeError(checkout.stderr or checkout.stdout or f"failed to checkout {ref}")
+    return clone_dir, _git_commit(clone_dir) or "unknown"
+
+
+def _normalize_manifest(layout: dict) -> dict:
+    for key in ("mat_docs", "mat_tests", "cursor_copy", "root_scripts_copy", "modes"):
+        if key not in layout:
+            raise ValueError(f"layout manifest is missing required section: {key}")
+    if "source_agents_for_mat" not in layout:
+        layout["source_agents_for_mat"] = "AGENTS.md"
+    if "source_readme_for_vendor" not in layout:
+        layout["source_readme_for_vendor"] = "README.md"
+    if "mat_sidecar" not in layout:
+        raise ValueError("layout manifest is missing required section: mat_sidecar")
+    return layout
+
+
+def _compare_file(source: Path, target: Path, source_root: Path, target_root: Path) -> FileDiff | None:
+    source_rel = source.relative_to(source_root).as_posix()
+    target_rel = target.relative_to(target_root).as_posix()
+
+    if not source.exists():
+        return FileDiff(source=source_rel, target=target_rel, change_type="conflict", source_sha256=None, target_sha256=None, preview="source file is missing")
+    if target.exists() and target.is_dir():
+        return FileDiff(source=source_rel, target=target_rel, change_type="conflict", source_sha256=_sha256_bytes(source.read_bytes()), target_sha256=None, preview="target path is a directory")
+
+    source_sha = _sha256_bytes(source.read_bytes())
+    if not target.exists():
+        return FileDiff(source=source_rel, target=target_rel, change_type="added", source_sha256=source_sha, target_sha256=None)
+
+    target_sha = _sha256_bytes(target.read_bytes())
+    if source_sha == target_sha:
+        return None
+
+    preview = ""
+    try:
+        preview = "\n".join(
+            difflib.unified_diff(
+                _read_text(target).splitlines(),
+                _read_text(source).splitlines(),
+                fromfile=f"target/{target_rel}",
+                tofile=f"source/{source_rel}",
+                lineterm="",
+            )
+        )
+    except UnicodeDecodeError:
+        preview = ""
+
+    return FileDiff(source=source_rel, target=target_rel, change_type="modified", source_sha256=source_sha, target_sha256=target_sha, preview=preview or None)
+
+
+def _legacy_migration_extra_paths(repo_root: Path) -> set[str]:
+    """Paths listed in mat-legacy-migrations (obsolete MAT surfaces) may exist on target without matching upstream."""
+    manifest = repo_root / "scripts" / "adoption" / "mat-legacy-migrations-v1.json"
+    if not manifest.is_file():
+        return set()
+    data = _load_json(manifest)
+    out: set[str] = set()
+    for entry in data.get("entries", []):
+        if not isinstance(entry, dict):
+            continue
+        raw = entry.get("path")
+        if not isinstance(raw, str) or not raw.strip():
+            continue
+        rel = raw.replace("\\", "/").strip()
+        while rel.startswith("./"):
+            rel = rel[2:]
+        out.add(rel)
+    return out
+
+
+def _compare_dir(
+    source_dir: Path,
+    target_dir: Path,
+    source_root: Path,
+    target_root: Path,
+    *,
+    legacy_allowed_extras: set[str] | None = None,
+) -> tuple[list[FileDiff], list[str]]:
+    diffs: list[FileDiff] = []
+    conflicts: list[str] = []
+
+    if not source_dir.exists():
+        conflicts.append(f"missing source directory: {source_dir.relative_to(source_root).as_posix()}")
+        return diffs, conflicts
+
+    source_files = _repo_paths_from_dir(source_dir)
+    target_files = _repo_paths_from_dir(target_dir)
+    source_rel = source_dir.relative_to(source_root).as_posix()
+    target_rel = target_dir.relative_to(target_root).as_posix()
+    allowed = legacy_allowed_extras or set()
+
+    for rel in sorted(set(target_files) - set(source_files)):
+        full = f"{target_rel}/{rel}" if target_rel else rel
+        if full in allowed:
+            continue
+        conflicts.append(f"target contains unmanaged file inside owned directory {target_rel}: {rel}")
+
+    for rel, source_path in source_files.items():
+        target_path = target_dir / rel
+        if target_path.exists() and target_path.is_dir():
+            conflicts.append(f"target path is a directory inside owned directory {target_rel}/{rel}")
+            continue
+        diff = _compare_file(source_path, target_path, source_root, target_root)
+        if diff is not None:
+            diffs.append(diff)
+
+    return diffs, conflicts
+
+
+def _run_agents_helper(repo_root: Path, *, dry_run: bool, inline_fallback: bool, backup_dir: Path | None) -> tuple[bool, str]:
+    cmd = [os.environ.get("PYTHON", "python3"), str(AGENTS_HELPER), "--repo-root", str(repo_root)]
+    if dry_run:
+        cmd.append("--dry-run")
+    if inline_fallback:
+        cmd.append("--inline-fallback")
+    if backup_dir is not None:
+        cmd.extend(["--backup-dir", str(backup_dir)])
+    completed = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+    output = (completed.stdout or "") + (completed.stderr or "")
+    if completed.returncode != 0:
+        raise RuntimeError(f"AGENTS helper failed: {output}")
+    needs = any(marker in output for marker in ("would update", "changed files:", "updated "))
+    return needs, output.strip()
+
+
+def _stage_target(target_root: Path, *, stage_mode: str) -> tuple[Path, str | None]:
+    if not _is_git_repo(target_root):
+        staging_root = Path(tempfile.mkdtemp(prefix="mat-update-stage-"))
+        shutil.copytree(target_root, staging_root, dirs_exist_ok=True)
+        return staging_root, f"mat/update-{target_root.name}-{staging_root.name[-8:]}"
+
+    staging_root = Path(tempfile.mkdtemp(prefix="mat-update-worktree-"))
+    branch_name = f"mat/update-{target_root.name}-{staging_root.name[-8:]}"
+    if not _git_status_clean(target_root):
+        shutil.copytree(target_root, staging_root, dirs_exist_ok=True)
+        return staging_root, branch_name
+
+    if stage_mode == "branch":
+        _git(["worktree", "add", "-b", branch_name, str(staging_root), "HEAD"], cwd=target_root)
+        return staging_root, branch_name
+
+    _git(["worktree", "add", "--detach", str(staging_root), "HEAD"], cwd=target_root)
+    return staging_root, branch_name
+
+
+def _run_legacy_cleanup_repo(repo_root: Path, *, dry_run: bool) -> None:
+    """Remove/quarantine obsolete MAT paths after staged layout copy (manifest-driven)."""
+    script = repo_root / "scripts" / "adoption" / "apply_mat_legacy_cleanup.py"
+    manifest = repo_root / "scripts" / "adoption" / "mat-legacy-migrations-v1.json"
+    footprint = repo_root / "scripts" / "adoption" / "mat-footprint-v1.json"
+    if not script.is_file() or not manifest.is_file() or not footprint.is_file():
+        return
+    cmd = [
+        os.environ.get("PYTHON", "python3"),
+        str(script),
+        "--repo-root",
+        str(repo_root),
+        "--manifest",
+        str(manifest),
+        "--footprint",
+        str(footprint),
+    ]
+    if dry_run:
+        cmd.append("--dry-run")
+    subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True, check=False)
+
+
+def _apply_mapping_set(
+    source_root: Path,
+    staging_root: Path,
+    items: list[MappingItem],
+    *,
+    inline_fallback: bool,
+    backup_dir: Path | None,
+    legacy_allowed_extras: set[str] | None = None,
+) -> tuple[list[FileDiff], list[str], bool, str]:
+    diffs: list[FileDiff] = []
+    conflicts: list[str] = []
+    agents_needed, agents_preview = _run_agents_helper(staging_root, dry_run=False, inline_fallback=inline_fallback, backup_dir=backup_dir)
+
+    for item in items:
+        source = source_root / item.source if item.source else None
+        target = staging_root / item.target
+        if item.kind == "generated":
+            if backup_dir is not None and target.exists():
+                backup = backup_dir / item.target
+                backup.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(target, backup)
+            _write_text(target, _render_mat_readme())
+            diffs.append(FileDiff(source="<generated>", target=item.target, change_type="generated", source_sha256=_sha256_text(_render_mat_readme()), target_sha256=_sha256_text(target.read_text(encoding="utf-8"))))
+            continue
+        assert source is not None
+        if item.kind == "file":
+            diff = _compare_file(source, target, source_root, staging_root)
+            if diff is None:
+                continue
+            if diff.change_type == "conflict":
+                conflicts.append(f"{diff.source} -> {diff.target}: {diff.preview}")
+                continue
+            if target.exists() and backup_dir is not None:
+                backup = backup_dir / item.target
+                backup.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(target, backup)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+            diffs.append(diff)
+            continue
+
+        dir_diffs, dir_conflicts = _compare_dir(source, target, source_root, staging_root, legacy_allowed_extras=legacy_allowed_extras)
+        conflicts.extend(dir_conflicts)
+        for diff in dir_diffs:
+            source_file = source_root / diff.source
+            target_file = staging_root / diff.target
+            if target_file.exists() and backup_dir is not None:
+                backup = backup_dir / diff.target
+                backup.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(target_file, backup)
+            target_file.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_file, target_file)
+            diffs.append(diff)
+
+    if agents_needed:
+        helper = [os.environ.get("PYTHON", "python3"), str(AGENTS_HELPER), "--repo-root", str(staging_root)]
+        if inline_fallback:
+            helper.append("--inline-fallback")
+        if backup_dir is not None:
+            helper.extend(["--backup-dir", str(backup_dir)])
+        completed = subprocess.run(helper, cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+        output = (completed.stdout or "") + (completed.stderr or "")
+        if completed.returncode != 0:
+            raise RuntimeError(f"AGENTS helper apply failed: {output}")
+        agents_preview = output.strip()
+
+    return diffs, conflicts, agents_needed, agents_preview
+
+
+def _audit_path(target_root: Path, audit_dir: str) -> Path:
+    audit_root = target_root / audit_dir
+    audit_root.mkdir(parents=True, exist_ok=True)
+    return audit_root / "update-mat-audit.jsonl"
+
+
+def _append_audit_record(target_root: Path, audit_dir: str, record: dict) -> Path:
+    audit_path = _audit_path(target_root, audit_dir)
+    with audit_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True))
+        handle.write("\n")
+    return audit_path
+
+
+def _plan_artifact_paths(target_root: Path, audit_dir: str) -> tuple[Path, Path]:
+    audit_root = target_root / audit_dir
+    audit_root.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    plan_path = audit_root / f"plan-update-{stamp}.json"
+    patch_path = audit_root / f"patch-update-{stamp}.patch"
+    return plan_path, patch_path
+
+
+def _plan_payload(*, plan: UpdatePlan, total_mappings: int, plan_path: Path, patch_path: Path) -> dict:
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "plan_file": str(plan_path),
+        "patch_file": str(patch_path),
+        "total_mappings": total_mappings,
+        "compatibility_snapshot": plan.compatibility_snapshot,
+        "plan": {
+            "upstream_source": plan.upstream_source,
+            "upstream_ref": plan.upstream_ref,
+            "upstream_commit": plan.upstream_commit,
+            "target_root": plan.target_root,
+            "target_baseline": plan.target_baseline,
+            "dry_run": plan.dry_run,
+            "stage_mode": plan.stage_mode,
+            "changed_files": [asdict(change) for change in plan.changed_files],
+            "agents_reconciliation_needed": plan.agents_reconciliation_needed,
+            "agents_preview": plan.agents_preview,
+            "conflicts": plan.conflicts,
+            "preserved_paths": plan.preserved_paths,
+            "rollback_hint": plan.rollback_hint,
+            "compatibility_snapshot": plan.compatibility_snapshot,
+            "staging_path": plan.staging_path,
+            "staging_branch": plan.staging_branch,
+            "backup_dir": plan.backup_dir,
+            "legacy_cleanup_preview": plan.legacy_cleanup_preview,
+        },
+    }
+
+
+def _write_plan_artifacts(*, plan: UpdatePlan, total_mappings: int, target_root: Path, audit_dir: str) -> tuple[Path, Path]:
+    plan_path, patch_path = _plan_artifact_paths(target_root, audit_dir)
+    payload = _plan_payload(plan=plan, total_mappings=total_mappings, plan_path=plan_path, patch_path=patch_path)
+    plan_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    patch_path.write_text(_render_stdout(plan, total_mappings), encoding="utf-8")
+    return plan_path, patch_path
+
+
+def _load_plan_file(plan_path: Path) -> dict:
+    return json.loads(plan_path.read_text(encoding="utf-8"))
+
+
+def _ensure_plan_current(plan_payload: dict, target_root: Path) -> None:
+    plan = plan_payload.get("plan", {})
+    if Path(plan.get("target_root", "")).resolve() != target_root.resolve():
+        raise RuntimeError(f"plan target mismatch: {plan.get('target_root')}")
+    for change in plan.get("changed_files", []):
+        target_rel = change["target"]
+        current = target_root / target_rel
+        target_sha = change.get("target_sha256")
+        if target_sha is None:
+            if current.exists():
+                raise RuntimeError(f"target drifted for {target_rel}")
+            continue
+        if not current.exists():
+            raise RuntimeError(f"target drifted for {target_rel}")
+        if current.is_dir():
+            raise RuntimeError(f"target drifted for {target_rel}")
+        if _sha256_bytes(current.read_bytes()) != target_sha:
+            raise RuntimeError(f"target drifted for {target_rel}")
+
+
+def _preview_lines(changes: list[FileDiff], max_lines: int = 120) -> list[str]:
+    lines: list[str] = []
+    for change in changes:
+        lines.append(f"{change.change_type.upper()}: {change.target}")
+        if change.preview:
+            lines.extend(change.preview.splitlines())
+        if len(lines) >= max_lines:
+            lines.append("... preview truncated ...")
+            break
+    return lines
+
+
+def _collect_plan(*, source_root: Path, target_root: Path, layout: dict, footprint: dict, source_input: str, source_ref: str, dry_run: bool, stage_mode: str, inline_fallback: bool, backup_dir: Path | None, audit_dir: str) -> UpdatePlan:
+    items = _layout_mappings(layout)
+    legacy_allowed_extras = _legacy_migration_extra_paths(target_root)
+    compatibility_snapshot = build_compatibility_snapshot(layout_manifest=layout, footprint_manifest=footprint)
+    preserved = list(footprint.get("target_repo", {}).get("preserve_paths", []))
+    for extra in layout.get("modes", {}).get("existing-project", {}).get("never_overwrite_root", []):
+        if extra not in preserved:
+            preserved.append(extra)
+    for extra in ("docs/current-plan.md", "docs/long-run-state.md", "build-result.md", "verify-result.md"):
+        if extra not in preserved:
+            preserved.append(extra)
+
+    conflicts: list[str] = []
+    diffs: list[FileDiff] = []
+
+    for item in items:
+        if item.target in preserved:
+            conflicts.append(f"manifest incorrectly includes preserved path: {item.target}")
+
+    agents_needed, agents_preview = _run_agents_helper(target_root, dry_run=True, inline_fallback=inline_fallback, backup_dir=backup_dir)
+
+    for item in items:
+        source_path = source_root / item.source if item.source else None
+        target_path = target_root / item.target
+        if item.kind == "generated":
+            generated = _render_mat_readme()
+            target_text = target_path.read_text(encoding="utf-8") if target_path.exists() else None
+            if target_text != generated:
+                diffs.append(FileDiff(source="<generated>", target=item.target, change_type="generated", source_sha256=_sha256_text(generated), target_sha256=_sha256_text(target_text) if target_text is not None else None, preview=None if target_text is None else "generated file differs"))
+            continue
+        assert source_path is not None
+        if item.kind == "file":
+            diff = _compare_file(source_path, target_path, source_root, target_root)
+            if diff is not None:
+                if diff.change_type == "conflict":
+                    conflicts.append(f"{diff.source} -> {diff.target}: {diff.preview}")
+                else:
+                    diffs.append(diff)
+            continue
+        dir_diffs, dir_conflicts = _compare_dir(
+            source_path, target_path, source_root, target_root, legacy_allowed_extras=legacy_allowed_extras
+        )
+        diffs.extend(dir_diffs)
+        conflicts.extend(dir_conflicts)
+
+    staging_path: str | None = None
+    staging_branch: str | None = None
+    final_backup_dir: str | None = None
+    if not dry_run and not conflicts:
+        staged_root, staging_branch = _stage_target(target_root, stage_mode=stage_mode)
+        staging_path = str(staged_root)
+        if backup_dir is not None:
+            final_backup_dir = str(backup_dir)
+        else:
+            final_backup_dir = str(staged_root / ".mat-update-backups")
+            backup_dir = Path(final_backup_dir)
+        applied_diffs, apply_conflicts, agents_needed_apply, agents_preview_apply = _apply_mapping_set(
+            source_root,
+            staged_root,
+            items,
+            inline_fallback=inline_fallback,
+            backup_dir=backup_dir,
+            legacy_allowed_extras=legacy_allowed_extras,
+        )
+        diffs = applied_diffs
+        conflicts.extend(apply_conflicts)
+        agents_needed = agents_needed or agents_needed_apply
+        if agents_preview_apply:
+            agents_preview = agents_preview_apply
+
+        if staging_path:
+            _run_legacy_cleanup_repo(Path(staging_path), dry_run=False)
+
+    legacy_cleanup_preview = _legacy_cleanup_preview_payload(target_root, audit_dir) if dry_run else []
+
+    rollback_hint = f"remove staging worktree at {staging_path}" if staging_path else f"restore from backups under {final_backup_dir or (target_root / audit_dir)}"
+    return UpdatePlan(
+        upstream_source=source_input,
+        upstream_ref=source_ref,
+        upstream_commit=_git_commit(source_root) or "unknown",
+        target_root=str(target_root),
+        target_baseline=_git_commit(target_root),
+        dry_run=dry_run,
+        stage_mode=stage_mode,
+        changed_files=diffs,
+        agents_reconciliation_needed=agents_needed,
+        agents_preview=agents_preview,
+        conflicts=conflicts,
+        preserved_paths=preserved,
+        rollback_hint=rollback_hint,
+        compatibility_snapshot=compatibility_snapshot,
+        staging_path=staging_path,
+        staging_branch=staging_branch,
+        backup_dir=final_backup_dir,
+        legacy_cleanup_preview=legacy_cleanup_preview,
+    )
+
+
+def _render_stdout(plan: UpdatePlan, total_mappings: int) -> str:
+    lines = ["MAT update dry-run" if plan.dry_run else "MAT update apply stage"]
+    lines.extend([
+        f"source: {plan.upstream_source}@{plan.upstream_ref} ({plan.upstream_commit})",
+        f"target: {plan.target_root}",
+        f"stage mode: {plan.stage_mode}",
+        f"dry-run: {str(plan.dry_run).lower()}",
+        f"mappings considered: {total_mappings}",
+        f"changes detected: {len(plan.changed_files)}",
+        f"AGENTS reconciliation needed: {str(plan.agents_reconciliation_needed).lower()}",
+        f"conflicts: {len(plan.conflicts)}",
+    ])
+    if plan.compatibility_snapshot:
+        lines.append(f"footprint manifest: {plan.compatibility_snapshot.get('manifest_name')}")
+        lines.append(f"compatibility paths: {plan.compatibility_snapshot.get('managed_path_count')}")
+    if plan.staging_path:
+        lines.append(f"staging path: {plan.staging_path}")
+    if plan.staging_branch:
+        lines.append(f"staging branch: {plan.staging_branch}")
+    if plan.backup_dir:
+        lines.append(f"backup dir: {plan.backup_dir}")
+    lines.append("")
+    lines.append("Legacy cleanup preview (target tree, non-mutating):")
+    if plan.legacy_cleanup_preview:
+        for row in plan.legacy_cleanup_preview:
+            succ = row.get("successor") or "n/a"
+            lines.append(f"  [{row['action']}] {row['path']} (handling={row['handling']}, successor={succ})")
+    else:
+        lines.append("  (no legacy migration tools/manifest on target, or no decisions)")
+    lines.append("")
+    lines.append("Patch preview:")
+    lines.extend(_preview_lines(plan.changed_files))
+    lines.append("")
+    lines.append("AGENTS reconciliation:")
+    lines.extend(plan.agents_preview.splitlines() if plan.agents_preview else ["no AGENTS helper output"])
+    lines.append("")
+    lines.append("Preserved paths:")
+    lines.extend(f"- {path}" for path in plan.preserved_paths)
+    lines.append("")
+    lines.append("Rollback hint:")
+    lines.append(plan.rollback_hint)
+    if plan.conflicts:
+        lines.append("")
+        lines.append("Conflicts:")
+        lines.extend(f"- {item}" for item in plan.conflicts)
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _audit_record(*, plan: UpdatePlan, total_mappings: int, source_ref: str, operator: str | None, author: str | None, audit_path: Path) -> dict:
+    changed_summary = [f"{change.change_type}:{change.target}" for change in plan.changed_files]
+    approval_state = "dry-run" if plan.dry_run else "apply-staged"
+    if plan.conflicts:
+        approval_state = "blocked"
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "upstream_source": plan.upstream_source,
+        "source_repo": plan.upstream_source,
+        "upstream_ref": source_ref,
+        "upstream_commit": plan.upstream_commit,
+        "target_root": plan.target_root,
+        "target_baseline": plan.target_baseline,
+        "final_target_reference": plan.staging_path or plan.target_baseline,
+        "final_commit_or_pr_reference": None,
+        "operator": operator,
+        "author": author,
+        "mode": "dry-run" if plan.dry_run else "apply",
+        "stage_mode": plan.stage_mode if not plan.dry_run else None,
+        "approval_state": approval_state,
+        "conflict_state": "blocked" if plan.conflicts else "clear",
+        "agents_reconciliation_needed": plan.agents_reconciliation_needed,
+        "changed_file_count": len(plan.changed_files),
+        "mappings_considered": total_mappings,
+        "diff_summary": changed_summary,
+        "agents_preview": plan.agents_preview,
+        "rollback_hint": plan.rollback_hint,
+        "compatibility_snapshot": plan.compatibility_snapshot,
+        "backup_dir": plan.backup_dir,
+        "staging_path": plan.staging_path,
+        "staging_branch": plan.staging_branch,
+        "stdout_preview": _preview_lines(plan.changed_files),
+        "audit_path": str(audit_path),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    target_root = _repo_root(args.target)
+    manifest_path = Path(args.manifest).expanduser().resolve()
+    footprint_path = Path(args.footprint).expanduser().resolve()
+    layout = _normalize_manifest(_load_layout_manifest(manifest_path))
+    footprint = _load_footprint_manifest(footprint_path)
+
+    try:
+        source_root, _ = _source_tree(args.source, args.ref)
+    except Exception as exc:
+        print(f"update-mat: failed to prepare source tree: {exc}", file=os.sys.stderr)
+        return 1
+
+    plan_path: Path | None = None
+    patch_path: Path | None = None
+    try:
+        if args.apply and not args.approved:
+            raise RuntimeError("approval required before commit or PR creation")
+
+        if args.apply and not args.plan_file:
+            raise RuntimeError("apply mode requires --plan-file from a prior dry-run")
+
+        if args.apply:
+            loaded_plan = _load_plan_file(Path(args.plan_file).expanduser().resolve())
+            _ensure_plan_current(loaded_plan, target_root)
+
+        plan = _collect_plan(
+            source_root=source_root,
+            target_root=target_root,
+            layout=layout,
+            footprint=footprint,
+            source_input=args.source,
+            source_ref=args.ref,
+            dry_run=not args.apply,
+            stage_mode=args.stage_mode,
+            inline_fallback=args.inline_fallback,
+            backup_dir=Path(args.backup_dir).expanduser().resolve() if args.backup_dir else None,
+            audit_dir=args.audit_dir,
+        )
+        if not args.apply:
+            plan_path, patch_path = _write_plan_artifacts(plan=plan, total_mappings=len(_layout_mappings(layout)), target_root=target_root, audit_dir=args.audit_dir)
+    except Exception as exc:
+        print(f"update-mat: {exc}", file=os.sys.stderr)
+        return 1
+
+    total_mappings = len(_layout_mappings(layout))
+    audit_path = _audit_path(target_root, args.audit_dir)
+    record = _audit_record(
+        plan=plan,
+        total_mappings=total_mappings,
+        source_ref=args.ref,
+        operator=os.environ.get("USER") or os.environ.get("USERNAME"),
+        author=os.environ.get("GIT_AUTHOR_NAME"),
+        audit_path=audit_path,
+    )
+    _append_audit_record(target_root, args.audit_dir, record)
+
+    if args.apply:
+        print("update-mat: dry-run=no")
+        if plan.staging_path:
+            print(f"staging-worktree={plan.staging_path}")
+        if plan.staging_branch:
+            print(f"branch={plan.staging_branch}")
+        print(f"footprint-file={footprint_path}")
+        print("approval required before commit or PR creation")
+    else:
+        print("update-mat: dry-run=yes")
+        if plan_path is not None:
+            print(f"plan-file={plan_path}")
+        if patch_path is not None:
+            print(f"patch-file={patch_path}")
+        print(f"footprint-file={footprint_path}")
+        print(f"audit-file={audit_path}")
+        print(f"agents_reconciliation_needed: {plan.agents_reconciliation_needed}")
+
+    print(_render_stdout(plan, total_mappings), end="")
+
+    if plan.conflicts:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/adoption/update_mat_contracts.py
+++ b/scripts/adoption/update_mat_contracts.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+EXPECTED_ROLE_NAMES = (
+    "updater",
+    "watcher",
+    "scanner",
+    "analyzer",
+    "architect",
+    "generator",
+    "test",
+    "ci",
+    "reviewer",
+    "security",
+    "rollback",
+)
+
+REQUIRED_HANDOFF_PATHS = (
+    "docs/current-plan.md",
+    "build-result.md",
+    "verify-result.md",
+)
+
+
+@dataclass(slots=True)
+class AdvisorTaskSessionSummary:
+    schema_version: str
+    session_kind: str
+    role: str
+    session_id: str
+    task_id: str
+    primary_artifact: str
+    input_artifacts: list[str]
+    decision: str
+    status: str
+    summary: str
+    risks: list[str]
+    follow_ups: list[str]
+    approvals: list[str]
+    timestamp_utc: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_footprint_manifest(path: Path) -> dict[str, Any]:
+    manifest = load_json(path)
+    validate_footprint_manifest(manifest)
+    return manifest
+
+
+def _require_list_of_strings(value: Any, *, field: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item.strip() for item in value):
+        raise ValueError(f"{field} must be a list of non-empty strings")
+    return [item.strip() for item in value]
+
+
+def validate_footprint_manifest(manifest: dict[str, Any]) -> None:
+    if manifest.get("schema_version") not in {"1", "1.0.0"}:
+        raise ValueError(f"unsupported footprint schema version: {manifest.get('schema_version')}")
+
+    target_repo = manifest.get("target_repo")
+    if not isinstance(target_repo, dict):
+        raise ValueError("footprint manifest is missing target_repo")
+
+    preserve_paths = _require_list_of_strings(target_repo.get("preserve_paths"), field="target_repo.preserve_paths")
+    protected_handoffs = _require_list_of_strings(
+        target_repo.get("protected_handoff_paths"),
+        field="target_repo.protected_handoff_paths",
+    )
+    roles = _require_list_of_strings(target_repo.get("roles"), field="target_repo.roles")
+
+    if tuple(roles) != EXPECTED_ROLE_NAMES:
+        raise ValueError("footprint manifest roles do not match the updater role contract")
+
+    if not preserve_paths:
+        raise ValueError("footprint manifest must preserve at least one path")
+    if not protected_handoffs:
+        raise ValueError("footprint manifest must define protected handoff paths")
+
+    required_doc_keys = {
+        "documentation_index",
+        "architecture_doc",
+        "role_prompt_template",
+        "summary_schema",
+        "summary_examples",
+    }
+    docs = target_repo.get("docs")
+    if not isinstance(docs, dict):
+        raise ValueError("footprint manifest is missing target_repo.docs")
+    missing_doc_keys = sorted(required_doc_keys - set(docs))
+    if missing_doc_keys:
+        raise ValueError(f"footprint manifest is missing target_repo.docs keys: {', '.join(missing_doc_keys)}")
+
+    for key in required_doc_keys:
+        value = docs.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"footprint manifest target_repo.docs.{key} must be a non-empty string")
+
+    allow = target_repo.get("allow")
+    if not isinstance(allow, dict):
+        raise ValueError("footprint manifest is missing target_repo.allow")
+
+    if allow.get("dry_run_default") is not True:
+        raise ValueError("footprint manifest must keep dry-run as the default")
+    if allow.get("apply_requires_approval") is not True:
+        raise ValueError("footprint manifest must require approval before apply")
+    if allow.get("auto_commit") is not False:
+        raise ValueError("footprint manifest must forbid auto-commit")
+    if allow.get("auto_pr") is not False:
+        raise ValueError("footprint manifest must forbid auto-PR creation")
+    if allow.get("preserve_product_agents") is not True:
+        raise ValueError("footprint manifest must preserve product-owned AGENTS.md content")
+
+
+def build_compatibility_snapshot(*, layout_manifest: dict[str, Any], footprint_manifest: dict[str, Any]) -> dict[str, Any]:
+    validate_footprint_manifest(footprint_manifest)
+
+    target_repo = footprint_manifest["target_repo"]
+    preserve_paths = _require_list_of_strings(target_repo["preserve_paths"], field="target_repo.preserve_paths")
+    protected_handoffs = _require_list_of_strings(
+        target_repo["protected_handoff_paths"],
+        field="target_repo.protected_handoff_paths",
+    )
+    role_names = _require_list_of_strings(target_repo["roles"], field="target_repo.roles")
+
+    layout_sources = sorted(
+        {item.get("src") for item in layout_manifest.get("mat_docs", []) if isinstance(item, dict) and isinstance(item.get("src"), str)}
+    )
+    layout_sources.extend(rel for rel in layout_manifest.get("mat_tests", []) if isinstance(rel, str))
+
+    managed_paths = sorted(
+        {
+            *layout_sources,
+            *preserve_paths,
+            *protected_handoffs,
+        }
+    )
+
+    return {
+        "manifest_name": footprint_manifest.get("name"),
+        "schema_version": footprint_manifest.get("schema_version"),
+        "documentation_index": target_repo["docs"]["documentation_index"],
+        "architecture_doc": target_repo["docs"]["architecture_doc"],
+        "role_prompt_template": target_repo["docs"]["role_prompt_template"],
+        "summary_schema": target_repo["docs"]["summary_schema"],
+        "summary_examples": target_repo["docs"]["summary_examples"],
+        "preserve_paths": preserve_paths,
+        "protected_handoff_paths": protected_handoffs,
+        "role_names": role_names,
+        "allow": target_repo["allow"],
+        "layout_source_count": len(layout_manifest.get("mat_docs", [])),
+        "layout_test_count": len(layout_manifest.get("mat_tests", [])),
+        "managed_paths": managed_paths,
+        "managed_path_count": len(managed_paths),
+        "protected_handoff_count": len(protected_handoffs),
+        "contract_health": {
+            "ready": True,
+            "reasons": [],
+        },
+    }
+
+
+def serialize_summary(summary: AdvisorTaskSessionSummary) -> str:
+    return json.dumps(summary.to_dict(), indent=2, sort_keys=True) + "\n"
+

--- a/scripts/check-worktrees.sh
+++ b/scripts/check-worktrees.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Check health and collisions across local git worktrees.
+set -euo pipefail
+
+STRICT=0
+if [ "${1:-}" = "--strict" ]; then
+  STRICT=1
+fi
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Not inside a git repository." >&2
+  exit 1
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+declare -a WORKTREE_PATHS=()
+declare -a WORKTREE_BRANCHES=()
+
+current_path=""
+while IFS= read -r line; do
+  case "$line" in
+    worktree\ *)
+      current_path="${line#worktree }"
+      WORKTREE_PATHS+=("$current_path")
+      WORKTREE_BRANCHES+=("detached")
+      ;;
+    branch\ refs/heads/*)
+      if [ ${#WORKTREE_BRANCHES[@]} -gt 0 ]; then
+        WORKTREE_BRANCHES[$((${#WORKTREE_BRANCHES[@]} - 1))]="${line#branch refs/heads/}"
+      fi
+      ;;
+  esac
+done < <(git worktree list --porcelain)
+
+if [ ${#WORKTREE_PATHS[@]} -eq 0 ]; then
+  echo "No worktrees found."
+  exit 1
+fi
+
+declare -a API_PORTS=()
+declare -a API_PORT_OWNERS=()
+declare -a CLIENT_PORTS=()
+declare -a CLIENT_PORT_OWNERS=()
+ISSUES=0
+
+echo "Worktree health report"
+echo "repo: $ROOT"
+echo ""
+
+for idx in "${!WORKTREE_PATHS[@]}"; do
+  path="${WORKTREE_PATHS[$idx]}"
+  branch="${WORKTREE_BRANCHES[$idx]}"
+  status="OK"
+  notes=()
+
+  if [ ! -d "$path" ]; then
+    status="STALE"
+    notes+=("path missing on disk")
+    ISSUES=$((ISSUES + 1))
+  else
+    if [ ! -f "$path/.env" ]; then
+      notes+=(".env missing")
+    fi
+    if [ ! -f "$path/.cursor/worktree/bootstrapped_at" ]; then
+      if [ "$path" = "$ROOT" ]; then
+        notes+=("bootstrap marker missing (main worktree, informational)")
+      else
+        status="WARN"
+        notes+=("bootstrap marker missing")
+        ISSUES=$((ISSUES + 1))
+      fi
+    fi
+
+    runtime_env="$path/.cursor/worktree/runtime.env"
+    api_port=""
+    client_port=""
+    if [ -f "$runtime_env" ]; then
+      api_port="$(awk -F= '/^OBSERVABILITY_PORT=/{print $2}' "$runtime_env" | tail -n1)"
+      client_port="$(awk -F= '/^OBSERVABILITY_CLIENT_PORT=/{print $2}' "$runtime_env" | tail -n1)"
+    fi
+
+    if [ -n "$api_port" ]; then
+      owner=""
+      j=0
+      while [ "$j" -lt "${#API_PORTS[@]}" ]; do
+        if [ "${API_PORTS[$j]}" = "$api_port" ]; then
+          owner="${API_PORT_OWNERS[$j]}"
+          break
+        fi
+        j=$((j + 1))
+      done
+      if [ -n "$owner" ]; then
+        status="WARN"
+        notes+=("api port collision with $owner")
+        ISSUES=$((ISSUES + 1))
+      else
+        API_PORTS+=("$api_port")
+        API_PORT_OWNERS+=("$path")
+      fi
+    fi
+
+    if [ -n "$client_port" ]; then
+      owner=""
+      j=0
+      while [ "$j" -lt "${#CLIENT_PORTS[@]}" ]; do
+        if [ "${CLIENT_PORTS[$j]}" = "$client_port" ]; then
+          owner="${CLIENT_PORT_OWNERS[$j]}"
+          break
+        fi
+        j=$((j + 1))
+      done
+      if [ -n "$owner" ]; then
+        status="WARN"
+        notes+=("client port collision with $owner")
+        ISSUES=$((ISSUES + 1))
+      else
+        CLIENT_PORTS+=("$client_port")
+        CLIENT_PORT_OWNERS+=("$path")
+      fi
+    fi
+  fi
+
+  echo "- branch: $branch"
+  echo "  path: $path"
+  echo "  status: $status"
+  if [ ${#notes[@]} -gt 0 ]; then
+    echo "  notes: ${notes[*]}"
+  fi
+done
+
+echo ""
+if [ "$ISSUES" -eq 0 ]; then
+  echo "Result: PASS (no collisions or stale worktrees detected)."
+  exit 0
+fi
+
+echo "Result: WARN (${ISSUES} issue(s) detected)."
+if [ "$STRICT" -eq 1 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Operator diagnostics for local workflow readiness.
+set -euo pipefail
+
+RUN_FULL=0
+COST_HYGIENE=0
+LEGACY_CLEANUP_REPORT=0
+if [ "${1:-}" = "--full" ]; then
+  RUN_FULL=1
+elif [ "${1:-}" = "--cost-hygiene" ] || [ "${1:-}" = "cost-hygiene" ]; then
+  COST_HYGIENE=1
+elif [ "${1:-}" = "--legacy-cleanup" ] || [ "${1:-}" = "legacy-cleanup" ]; then
+  LEGACY_CLEANUP_REPORT=1
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/ensure-bun-path.sh
+. "$ROOT/scripts/lib/ensure-bun-path.sh"
+cd "$ROOT"
+
+if [ "$COST_HYGIENE" = "1" ]; then
+  echo "doctor: cost & context hygiene (non-fatal diagnostic)"
+  set +e
+  python3 "$ROOT/scripts/validate_cost_context_hygiene_pack.py" \
+    --repo-root "$ROOT" \
+    --report \
+    --no-fail
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    echo "doctor: unexpected validator exit: $rc" >&2
+    exit 1
+  fi
+  echo "doctor: cost-hygiene section complete (see artifacts/cost-hygiene/ for JSON)"
+  exit 0
+fi
+
+if [ "$LEGACY_CLEANUP_REPORT" = "1" ]; then
+  echo "doctor: MAT legacy cleanup audit summary (artifacts/update-mat/legacy-cleanup.jsonl)"
+  python3 "$ROOT/scripts/adoption/apply_mat_legacy_cleanup.py" --repo-root "$ROOT" --report
+  exit 0
+fi
+
+echo "doctor: repo=$ROOT"
+
+check_file() {
+  local path="$1"
+  if [ -e "$path" ]; then
+    echo "OK   $path"
+  else
+    echo "FAIL $path"
+    return 1
+  fi
+}
+
+FAILED=0
+
+for path in \
+  ".cursor/hooks.json" \
+  ".cursor/worktrees.json" \
+  ".cursor/mcp.json" \
+  ".cursor/commands/mat-doctor.md" \
+  ".cursor/commands/mat-wt-check.md" \
+  ".cursor/agents/test-writer.md" \
+  ".cursor/agents/style-reviewer.md" \
+  "scripts/setup-dev.sh" \
+  "scripts/check-worktrees.sh" \
+  "scripts/phase1-verify.sh"; do
+  check_file "$path" || FAILED=1
+done
+
+if command -v python3 >/dev/null 2>&1; then
+  echo "OK   python3=$(python3 --version 2>&1)"
+else
+  echo "FAIL python3 missing"
+  FAILED=1
+fi
+
+if command -v bun >/dev/null 2>&1; then
+  echo "OK   bun=$(bun --version 2>&1)"
+else
+  echo "WARN bun missing (required for observability apps)"
+fi
+
+python3 - <<'PY' || FAILED=1
+import json
+from pathlib import Path
+
+for path in [".cursor/hooks.json", ".cursor/worktrees.json", ".cursor/mcp.json"]:
+    json.loads(Path(path).read_text())
+print("OK   core JSON files parse")
+PY
+
+bash scripts/check-worktrees.sh --strict || FAILED=1
+
+if [ "$RUN_FULL" -eq 1 ]; then
+  echo "Running full verification via scripts/phase1-verify.sh ..."
+  bash scripts/phase1-verify.sh || FAILED=1
+fi
+
+if [ "$FAILED" -eq 0 ]; then
+  echo "doctor result: PASS"
+  exit 0
+fi
+
+echo "doctor result: FAIL"
+exit 1

--- a/scripts/lib/ensure-bun-path.sh
+++ b/scripts/lib/ensure-bun-path.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Prepend the default Bun install directory when `bun` is not on PATH.
+# Interactive shells usually load ~/.zshrc; Cursor agent terminals, CI-like shells,
+# and automation often do not — this keeps `bun run dev` and phase1-verify reliable.
+#
+# shellcheck shell=bash
+# Source from other scripts: . "$ROOT/scripts/lib/ensure-bun-path.sh"
+
+if ! command -v bun >/dev/null 2>&1; then
+  _bun_home="${BUN_INSTALL:-$HOME/.bun}"
+  for _d in "${_bun_home}/bin" "${HOME}/.bun/bin"; do
+    if [ -x "${_d}/bun" ]; then
+      export PATH="${_d}:${PATH}"
+      break
+    fi
+  done
+  unset _d _bun_home
+fi

--- a/scripts/lib/pick-free-port.sh
+++ b/scripts/lib/pick-free-port.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Pick the first TCP port in [BASE, END] that can bind on 127.0.0.1 (for dev servers).
+# Prints the port number to stdout, or exits 1 if none found.
+# shellcheck shell=bash
+
+pick_free_port() {
+  local base="${1:?base port required}"
+  local end="${2:-$((base + 100))}"
+  python3 - "$base" "$end" <<'PY'
+import socket
+import sys
+
+base = int(sys.argv[1])
+end = int(sys.argv[2])
+
+
+def port_is_available(port: int) -> bool:
+    probes = [
+        (socket.AF_INET, ("127.0.0.1", port)),
+        (socket.AF_INET6, ("::1", port)),
+    ]
+    sockets = []
+    try:
+        for family, address in probes:
+            try:
+                sock = socket.socket(family, socket.SOCK_STREAM)
+            except OSError:
+                continue
+            try:
+                sock.bind(address)
+            except OSError:
+                sock.close()
+                return False
+            sockets.append(sock)
+        return True
+    finally:
+        for sock in sockets:
+            sock.close()
+
+
+for port in range(base, end + 1):
+    if port_is_available(port):
+        print(port)
+        sys.exit(0)
+
+print("no free port in range", base, "..", end, file=sys.stderr)
+sys.exit(1)
+PY
+}

--- a/scripts/parallelism-gate.sh
+++ b/scripts/parallelism-gate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Parallelism gate helper: create two git worktrees and run bootstrap_worktree.sh in each.
+# Requires: git, a clean working tree (commit any changes first).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Not a git repository: $ROOT" >&2
+  exit 1
+fi
+
+WT_BASE="${PARALLELISM_WT_BASE:-$ROOT/../.phase1-worktrees}"
+mkdir -p "$WT_BASE"
+
+BR1="phase1-parallel-a"
+BR2="phase1-parallel-b"
+P1="$WT_BASE/$BR1"
+P2="$WT_BASE/$BR2"
+
+cleanup() {
+  git worktree remove -f "$P1" 2>/dev/null || true
+  git worktree remove -f "$P2" 2>/dev/null || true
+  git branch -D "$BR1" 2>/dev/null || true
+  git branch -D "$BR2" 2>/dev/null || true
+}
+
+if [ "${PARALLELISM_CLEAN:-1}" = "1" ]; then
+  trap cleanup EXIT
+fi
+
+git worktree add "$P1" -b "$BR1"
+git worktree add "$P2" -b "$BR2"
+
+(
+  cd "$P1"
+  bash .cursor/hooks/bootstrap_worktree.sh builder-agent
+)
+
+(
+  cd "$P2"
+  bash .cursor/hooks/bootstrap_worktree.sh verifier-agent
+)
+
+echo "parallelism gate: OK (bootstrap ran in two worktrees)"
+echo "worktrees: $P1 , $P2"

--- a/scripts/phase1-verify.sh
+++ b/scripts/phase1-verify.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Phase 1 automated verification (Python unit tests + optional Bun server/client smoke).
+# Env skips: PHASE1_VERIFY_SKIP_UNITTEST=1, PHASE1_VERIFY_SKIP_BUN=1, PHASE1_VERIFY_SKIP_CLIENT=1.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/ensure-bun-path.sh
+. "$ROOT/scripts/lib/ensure-bun-path.sh"
+cd "$ROOT"
+mkdir -p artifacts/phase1
+
+# MAT adopted sidecar repos (bootstrap) ship `.mat/README.md` and usually omit MAT-source-only trees.
+MAT_ADOPTED_SIDECAR=0
+if [ -f "$ROOT/.mat/README.md" ]; then
+  MAT_ADOPTED_SIDECAR=1
+fi
+
+# Rolling local verification log. Dated sign-off logs under artifacts/phase1/ are the
+# tracked distilled evidence; this file is local mutable runtime exhaust.
+REPORT="$ROOT/artifacts/phase1/phase1-verify.log"
+{
+  echo "phase1-verify started: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "repo: $ROOT"
+  echo
+
+   echo "=== workflow artifact validation ==="
+   VA_ARGS=(--repo-root "$ROOT" --require-current-plan)
+   if [ "$MAT_ADOPTED_SIDECAR" = "1" ]; then
+     VA_ARGS+=(--optional-handoff-artifacts)
+   fi
+   python3 .cursor/scripts/validate_artifacts.py "${VA_ARGS[@]}"
+   echo "workflow artifacts: OK"
+
+  echo
+  echo "=== closeout freshness and coherence ==="
+  python3 scripts/validate_closeout_coherence.py --repo-root "$ROOT"
+  echo "closeout coherence: OK"
+
+  echo
+  echo "=== cost & context hygiene pack ==="
+  # MAT source repo: strict (no .mat/cost-hygiene-adoption.json) → fail-fast. Adopted repos
+  # with warn_first may set CURSOR_MAT_COST_HYGIENE_ENFORCE=strict in CI to hard-fail until
+  # the team merges the suggested ignore fragments, or pass --enforce strict via a forked verify step.
+  python3 scripts/validate_cost_context_hygiene_pack.py --repo-root "$ROOT" --enforce auto
+  echo "cost context hygiene pack: OK"
+
+  echo "=== hooks.json parse (python) ==="
+  python3 - <<'PY'
+import json, pathlib
+p = pathlib.Path(".cursor/hooks.json")
+data = json.loads(p.read_text())
+assert data.get("version") == 1
+assert isinstance(data.get("hooks"), dict)
+print("hooks.json: OK, events:", len(data["hooks"]))
+PY
+
+  echo
+  echo "=== repo workflow surface checks ==="
+  python3 - <<'PY'
+import json
+from pathlib import Path
+
+required_paths = [
+    Path(".cursor/agents/test-writer.md"),
+    Path(".cursor/agents/style-reviewer.md"),
+    Path(".cursor/commands/mat-wt-check.md"),
+    Path(".cursor/commands/mat-doctor.md"),
+    Path("scripts/check-worktrees.sh"),
+    Path("scripts/doctor.sh"),
+    Path("scripts/setup-dev.sh"),
+]
+missing = [str(p) for p in required_paths if not p.exists()]
+if missing:
+    raise SystemExit(f"Missing expected workflow surfaces: {missing}")
+
+worktrees = json.loads(Path(".cursor/worktrees.json").read_text())
+names = {entry.get("name") for entry in worktrees.get("worktrees", [])}
+for required_name in ("builder-agent", "verifier-agent"):
+    if required_name not in names:
+        raise SystemExit(f"worktrees.json missing expected role: {required_name}")
+if not isinstance(worktrees.get("optional_cloud_agent_templates", []), list):
+    raise SystemExit("worktrees.json optional_cloud_agent_templates must be a list")
+print("workflow surfaces: OK")
+PY
+
+  echo
+  echo "=== script executability checks ==="
+  for script in \
+    scripts/phase1-verify.sh \
+    scripts/start-system.sh \
+    scripts/parallelism-gate.sh \
+    scripts/check-worktrees.sh \
+    scripts/doctor.sh \
+    scripts/setup-dev.sh \
+    scripts/adoption/apply_cost_hygiene_bootstrap.py \
+    scripts/adoption/detect_cost_hygiene_template.py \
+    .cursor/hooks/bootstrap_worktree.sh; do
+    if [ ! -x "$script" ]; then
+      echo "script not executable: $script" >&2
+      exit 1
+    fi
+  done
+  echo "script executability: OK"
+
+  if [ "${PHASE1_VERIFY_SKIP_UNITTEST:-0}" = "1" ]; then
+    echo
+    echo "=== python unittest (tests/): SKIPPED via PHASE1_VERIFY_SKIP_UNITTEST=1 ==="
+  elif [ "$MAT_ADOPTED_SIDECAR" = "1" ] && [ -d "$ROOT/.mat/tests" ]; then
+    echo
+    echo "=== python unittest (.mat/tests/) [MAT adopted sidecar profile] ==="
+    python3 -m unittest discover -s .mat/tests -p 'test_*.py' -v
+  else
+    echo
+    echo "=== python unittest (tests/) ==="
+    python3 -m unittest discover -s tests -p 'test_*.py' -v
+  fi
+
+  if [ "$MAT_ADOPTED_SIDECAR" = "0" ] && [ -f "$ROOT/scripts/adoption/mat-legacy-fingerprints.py" ]; then
+    echo
+    echo "=== mat legacy fingerprint verify-all ==="
+    python3 "$ROOT/scripts/adoption/mat-legacy-fingerprints.py" --repo "$ROOT" --verify-all
+    echo "mat legacy fingerprint verify-all: OK"
+  fi
+
+  echo
+  echo "=== optional tooling gate (mcp.json) ==="
+  python3 - <<'PY'
+import json, pathlib
+# Phase 1 baseline: committed MCP config must parse.
+data = json.loads(pathlib.Path(".cursor/mcp.json").read_text())
+assert isinstance(data, dict)
+print("mcp.json: OK (valid JSON, Phase 1 baseline)")
+PY
+
+  if [ "${PHASE1_VERIFY_SKIP_BUN:-0}" = "1" ]; then
+    echo
+    echo "=== bun observability smoke: SKIPPED via PHASE1_VERIFY_SKIP_BUN=1 ==="
+  elif [ ! -d "$ROOT/apps/server" ]; then
+    echo
+    echo "=== bun observability smoke: SKIPPED (apps/server not present; typical MAT adopted tree) ==="
+  elif command -v bun >/dev/null 2>&1; then
+    echo
+    echo "=== bun observability smoke (apps/server) ==="
+    export OBSERVABILITY_DB_PATH="$ROOT/artifacts/phase1/phase1-events.sqlite"
+    export PORT="${PORT:-3011}"
+    cd "$ROOT/apps/server"
+    bun install
+    bun run src/index.ts &
+    PID=$!
+    cleanup_server() {
+      kill "$PID" >/dev/null 2>&1 || true
+      wait "$PID" 2>/dev/null || true
+    }
+    trap cleanup_server EXIT
+    sleep 1
+    HEALTH_RESPONSE="$(curl -fsS "http://127.0.0.1:${PORT}/health")"
+    printf '%s' "$HEALTH_RESPONSE" | python3 - <<'PY'
+import sys
+text = sys.stdin.read()
+print(text[:200])
+PY
+    echo
+    POST_RESPONSE="$(curl -fsS -X POST "http://127.0.0.1:${PORT}/events" \
+      -H 'Content-Type: application/json' \
+      -H 'X-Hook-Event: PostToolUse' \
+      -d '{"session_id":"phase1","tool_name":"Read","tool_input":{},"tool_output":"ok"}' \
+    )"
+    printf '%s' "$POST_RESPONSE" | python3 - <<'PY'
+import sys
+text = sys.stdin.read()
+print(text[:400])
+PY
+    echo
+    cleanup_server
+    trap - EXIT
+    echo "bun smoke: OK"
+  else
+    echo
+    echo "=== bun observability smoke: SKIPPED (bun not installed) ==="
+  fi
+
+  if [ "${PHASE1_VERIFY_SKIP_CLIENT:-0}" = "1" ]; then
+    echo
+    echo "=== bun observability client: SKIPPED via PHASE1_VERIFY_SKIP_CLIENT=1 ==="
+  elif [ ! -d "$ROOT/apps/client" ]; then
+    echo
+    echo "=== bun observability client: SKIPPED (apps/client not present) ==="
+  elif ! command -v bun >/dev/null 2>&1; then
+    echo
+    echo "=== bun observability client: SKIPPED (bun not installed) ==="
+  else
+    echo
+    echo "=== bun observability client (apps/client) ==="
+    if command -v node >/dev/null 2>&1; then
+      node_ver="$(node -v)"
+      node_major="${node_ver#v}"
+      node_major="${node_major%%.*}"
+      if [ -n "$node_major" ] && { [ "$node_major" -lt 20 ] 2>/dev/null || [ "$node_major" -ne 22 ] 2>/dev/null; }; then
+        echo "phase1-verify: WARN — Node ${node_ver} detected; CI pins Node 22 for apps/client (Vite 8 requires 20.19+)." >&2
+      fi
+    fi
+    cd "$ROOT/apps/client"
+    bun install --frozen-lockfile
+    bun run type-check
+    bun run test:vitest
+    bun run build
+    cd "$ROOT"
+    echo "bun observability client: OK"
+  fi
+
+  echo
+  echo "phase1-verify finished: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} 2>&1 | tee "$REPORT"
+
+echo "Wrote log: $REPORT"

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Lightweight local setup helper for operators.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/ensure-bun-path.sh
+. "$ROOT/scripts/lib/ensure-bun-path.sh"
+cd "$ROOT"
+
+echo "setup-dev: repo=$ROOT"
+
+if [ ! -f ".env" ] && [ -f ".env.sample" ]; then
+  cp ".env.sample" ".env"
+  echo "Created .env from .env.sample"
+else
+  echo ".env already present (or .env.sample missing) — skipped copy"
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  if [ ! -d ".venv" ]; then
+    python3 -m venv .venv
+    echo "Created Python virtualenv at .venv"
+  else
+    echo ".venv already exists — skipped"
+  fi
+else
+  echo "python3 not found — skipped virtualenv setup"
+fi
+
+if command -v bun >/dev/null 2>&1; then
+  (
+    cd apps/server
+    bun install
+  )
+  (
+    cd apps/client
+    bun install
+  )
+  echo "Installed Bun dependencies for apps/server and apps/client"
+else
+  echo "bun not found — skipped Bun installs"
+fi
+
+echo "Next steps:"
+echo "  1) source .venv/bin/activate  # if using Python venv"
+echo "  2) bash scripts/doctor.sh"
+echo "  3) bash scripts/start-system.sh"

--- a/scripts/start-system.sh
+++ b/scripts/start-system.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Start observability Bun API (apps/server) and Vite dashboard (apps/client).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/ensure-bun-path.sh
+. "$SCRIPT_DIR/lib/ensure-bun-path.sh"
+# shellcheck source=lib/pick-free-port.sh
+. "$SCRIPT_DIR/lib/pick-free-port.sh"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "bun is not installed or not on PATH." >&2
+  echo "Install Bun: https://bun.sh/docs/installation" >&2
+  exit 1
+fi
+
+if [ ! -f "$ROOT/apps/server/package.json" ] || [ ! -f "$ROOT/apps/client/package.json" ]; then
+  echo "Missing apps/server or apps/client package.json" >&2
+  exit 1
+fi
+
+DESIRED_API_PORT="${OBSERVABILITY_PORT:-${PORT:-3001}}"
+DESIRED_CLIENT_PORT="${OBSERVABILITY_CLIENT_PORT:-5173}"
+
+SERVER_PID=""
+CLIENT_PID=""
+
+cleanup() {
+  if [ -n "${CLIENT_PID:-}" ]; then kill "$CLIENT_PID" 2>/dev/null || true; fi
+  if [ -n "${SERVER_PID:-}" ]; then kill "$SERVER_PID" 2>/dev/null || true; fi
+}
+trap cleanup EXIT INT TERM
+
+if ! API_PORT="$(pick_free_port "$DESIRED_API_PORT")"; then
+  echo "Could not find a free TCP port for the observability API starting at ${DESIRED_API_PORT}." >&2
+  exit 1
+fi
+if [ "$API_PORT" != "$DESIRED_API_PORT" ]; then
+  echo "Note: port ${DESIRED_API_PORT} was in use; using ${API_PORT} for the observability API." >&2
+fi
+
+if ! CLIENT_PORT="$(pick_free_port "$DESIRED_CLIENT_PORT")"; then
+  echo "Could not find a free TCP port for the dashboard starting at ${DESIRED_CLIENT_PORT}." >&2
+  exit 1
+fi
+if [ "$CLIENT_PORT" != "$DESIRED_CLIENT_PORT" ]; then
+  echo "Note: port ${DESIRED_CLIENT_PORT} was in use; using ${CLIENT_PORT} for the dashboard." >&2
+fi
+
+export PORT="$API_PORT"
+export OBSERVABILITY_PORT="$API_PORT"
+export OBSERVABILITY_CLIENT_PORT="$CLIENT_PORT"
+
+if [ -z "${OBSERVABILITY_CORS_ORIGINS:-}" ]; then
+  export OBSERVABILITY_CORS_ORIGINS="http://127.0.0.1:${CLIENT_PORT},http://localhost:${CLIENT_PORT},http://127.0.0.1:${API_PORT},http://localhost:${API_PORT}"
+fi
+
+cd "$ROOT/apps/server"
+bun install
+bun run dev &
+SERVER_PID=$!
+
+sleep 0.3
+if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+  echo "Observability server exited immediately (is port ${API_PORT} already in use? Stop the other process or set PORT / OBSERVABILITY_PORT.)" >&2
+  exit 1
+fi
+
+_ok=0
+for _ in $(seq 1 100); do
+  if curl -fsS "http://127.0.0.1:${API_PORT}/health" >/dev/null 2>&1; then
+    _ok=1
+    break
+  fi
+  sleep 0.2
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "Observability server died while starting (check port ${API_PORT} and logs above)." >&2
+    exit 1
+  fi
+done
+if [ "$_ok" != 1 ]; then
+  echo "Observability server did not become ready on :${API_PORT}" >&2
+  exit 1
+fi
+if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+  echo "Observability server is not running after health check." >&2
+  exit 1
+fi
+
+cd "$ROOT/apps/client"
+export OBSERVABILITY_API_ORIGIN="http://127.0.0.1:${API_PORT}"
+bun install
+bun run dev &
+CLIENT_PID=$!
+
+sleep 0.5
+if ! kill -0 "$CLIENT_PID" 2>/dev/null; then
+  echo "Dashboard (Vite) exited immediately (see errors above)." >&2
+  exit 1
+fi
+
+_ok_client=0
+for _ in $(seq 1 80); do
+  if curl -fsS "http://127.0.0.1:${CLIENT_PORT}/" >/dev/null 2>&1; then
+    _ok_client=1
+    break
+  fi
+  sleep 0.15
+  if ! kill -0 "$CLIENT_PID" 2>/dev/null; then
+    echo "Dashboard (Vite) died while starting." >&2
+    exit 1
+  fi
+done
+if [ "$_ok_client" != 1 ]; then
+  echo "Dashboard did not respond on http://127.0.0.1:${CLIENT_PORT}/ in time." >&2
+  exit 1
+fi
+
+echo ""
+echo "Observability API: http://127.0.0.1:${API_PORT} (POST /events, GET /events, GET /health)"
+echo "Dashboard (Vite):  http://127.0.0.1:${CLIENT_PORT}"
+echo "Press Ctrl+C to stop both."
+echo ""
+
+wait

--- a/scripts/validate_closeout_coherence.py
+++ b/scripts/validate_closeout_coherence.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Validate closeout summaries against tracked comparison artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+STATUS_NAMES = ("observed", "manual_required", "runtime_blocked")
+WORD_TO_INT = {
+    "zero": 0,
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+}
+COUNT_TOKEN = r"(?P<count>\d+|zero|one|two|three|four|five|six|seven|eight|nine|ten)"
+STATUS_TOKEN = r"(?P<status>observed|manual_required|runtime_blocked)"
+ALL_CASES_PATTERN = re.compile(
+    rf"all\s+{COUNT_TOKEN}\s+(?:tracked|required|matrix)(?:\s+matrix)?\s+cases?\s+as\s+`{STATUS_TOKEN}`",
+    re.IGNORECASE,
+)
+STATUS_PAIR_PATTERN = re.compile(
+    rf"{COUNT_TOKEN}\s+`{STATUS_TOKEN}`\s+cases?",
+    re.IGNORECASE,
+)
+CLOSEOUT_SECTION_PATTERN = re.compile(
+    r"(?ims)^##\s+Closeout(?:\s+\(\d{4}-\d{2}-\d{2}\))?\s*$\s*(?P<body>.*?)(?=^##\s+.+$|\Z)"
+)
+POSTURE_HINT_PATTERN = re.compile(
+    r"(?i)\b(posture|summary|comparison|matrix|tracked\s+.*cases?|required\s+.*cases?)\b"
+)
+
+
+def _count_from_token(raw: str) -> int | None:
+    raw = raw.strip().lower()
+    if raw.isdigit():
+        return int(raw)
+    return WORD_TO_INT.get(raw)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_counts(counts: dict[str, int]) -> dict[str, int]:
+    return {status: int(counts.get(status, 0)) for status in STATUS_NAMES}
+
+
+def _extract_status_counts(text: str) -> tuple[dict[str, int], bool]:
+    claims: dict[str, int] = {}
+    saw_all_cases_pattern = False
+
+    for match in ALL_CASES_PATTERN.finditer(text):
+        count = _count_from_token(match.group("count"))
+        status = match.group("status").lower()
+        if count is None:
+            continue
+        saw_all_cases_pattern = True
+        claims = {name: 0 for name in STATUS_NAMES}
+        claims[status] = count
+
+    for match in STATUS_PAIR_PATTERN.finditer(text):
+        count = _count_from_token(match.group("count"))
+        status = match.group("status").lower()
+        if count is None:
+            continue
+        claims[status] = count
+
+    return _normalize_counts(claims), saw_all_cases_pattern
+
+
+def _closeout_body(text: str) -> str:
+    match = CLOSEOUT_SECTION_PATTERN.search(text)
+    if not match:
+        return ""
+    return match.group("body").strip()
+
+
+def _extract_posture_claim(text: str, *, surface: str) -> dict[str, int] | None:
+    claim_text = text if surface == "session_summary" else _closeout_body(text)
+    if not claim_text:
+        return None
+
+    counts, saw_all_cases_pattern = _extract_status_counts(claim_text)
+    if not any(counts.values()):
+        return None
+
+    non_zero_statuses = [status for status, count in counts.items() if count]
+    is_posture_claim = (
+        surface == "session_summary"
+        or saw_all_cases_pattern
+        or len(non_zero_statuses) >= 2
+        or bool(POSTURE_HINT_PATTERN.search(claim_text))
+    )
+    if not is_posture_claim:
+        return None
+    return counts
+
+
+def _status_counts_from_comparison(path: Path) -> dict[str, int]:
+    payload = _read_json(path)
+    raw_counts = payload.get("status_counts")
+    if not isinstance(raw_counts, dict):
+        return {}
+    return _normalize_counts(
+        {status: int(raw_counts.get(status, 0)) for status in STATUS_NAMES}
+    )
+
+
+def _is_mat_adopted_sidecar_layout(root: Path) -> bool:
+    """True when this tree looks like a MAT bootstrap sidecar (not the full MAT source repo)."""
+    marker = root / ".mat" / "README.md"
+    if not marker.is_file():
+        return False
+    try:
+        head = marker.read_text(encoding="utf-8")[:4000]
+    except OSError:
+        return False
+    return "MAT" in head and "sidecar" in head.lower()
+
+
+def validate_closeout_coherence(repo_root: Path | str) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    comparison_json = root / "artifacts" / "agent-traces" / "comparison.json"
+    issues: list[dict[str, str]] = []
+
+    if not comparison_json.is_file():
+        if _is_mat_adopted_sidecar_layout(root):
+            print(
+                "closeout coherence: SKIPPED (no artifacts/agent-traces/comparison.json in this "
+                "adopted tree; nothing to cross-check until you add a tracked comparison matrix)"
+            )
+            return {"ok": True, "issues": [], "skipped": True}
+        issues.append(
+            {
+                "path": str(comparison_json),
+                "code": "comparison_json_missing",
+                "message": "tracked comparison.json is required for closeout coherence checks",
+            }
+        )
+        return {"ok": False, "issues": issues}
+
+    source_counts = _status_counts_from_comparison(comparison_json)
+    for candidate, surface in (
+        (root / "build-result.md", "build_result"),
+        (root / "verify-result.md", "verify_result"),
+        (root / "docs" / "session-summary.md", "session_summary"),
+    ):
+        if not candidate.is_file():
+            continue
+        claims = _extract_posture_claim(
+            candidate.read_text(encoding="utf-8"), surface=surface
+        )
+        if claims is None:
+            continue
+        if claims != source_counts:
+            issues.append(
+                {
+                    "path": str(candidate),
+                    "code": "status_claim_mismatch",
+                    "message": "status claim does not match artifacts/agent-traces/comparison.json",
+                }
+            )
+
+    return {"ok": not issues, "issues": issues}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root (default: cwd)",
+    )
+    args = parser.parse_args(argv)
+    result = validate_closeout_coherence(args.repo_root)
+    if result["ok"]:
+        print("closeout coherence: OK")
+        return 0
+    for issue in result["issues"]:
+        print(f"{issue['code']}: {issue['path']} - {issue['message']}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_cost_context_hygiene_pack.py
+++ b/scripts/validate_cost_context_hygiene_pack.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Cost & context hygiene pack — structured validation (CI + --report doctor mode)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Final, Literal
+
+Severity = Literal["FAIL", "WARN", "INFO"]
+EnforceMode = Literal["strict", "warn_first", "auto"]
+
+RULE_REL = Path(".cursor/rules/cost-context-hygiene.mdc")
+IGNORE_REL = Path(".cursorignore")
+# Canonical template (generic fallback) + stack variants
+TEMPLATE_DEFAULT_REL = Path("docs/templates/cursorignore-mat-default")
+# Back-compat for tests and scripts that import TEMPLATE_REL
+TEMPLATE_REL = TEMPLATE_DEFAULT_REL
+ALL_TEMPLATE_RELS: Final[tuple[Path, ...]] = (
+    TEMPLATE_DEFAULT_REL,
+    Path("docs/templates/cursorignore-mat-node"),
+    Path("docs/templates/cursorignore-mat-python"),
+    Path("docs/templates/cursorignore-mat-wordpress"),
+    Path("docs/templates/cursorignore-mat-rails"),
+    Path("docs/templates/cursorignore-mat-shared.inc"),
+)
+ADOPTION_REL = Path(".mat/cost-hygiene-adoption.json")
+BEFORE_SUBMIT_REL = Path(".cursor/hooks/before_submit_prompt.py")
+
+# Honesty + contract strings (see `.cursor/rules/cost-context-hygiene.mdc`)
+RULE_REQUIRED_SUBSTRINGS: tuple[str, ...] = (
+    "alwaysApply: true",
+    "description:",
+    "@file",
+    "@Codebase",
+    "docs/context-budget-policy.md",
+    "docs/current-plan.md",
+    "docs/model-routing-policy.md",
+    "cannot block",
+)
+
+# Verifier / orchestration handoff (contract AC — stay narrow)
+VERIFIER_SUBSTRINGS: tuple[str, ...] = (
+    "verifier",
+    "build-result",
+)
+
+CURSORIGNORE_REQUIRED_FRAGMENTS: tuple[str, ...] = (
+    "node_modules",
+    "dist/",
+    "build/",
+    "coverage/",
+    "__pycache__",
+    "*.log",
+    ".env",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    code: str
+    severity: Severity
+    message: str
+    path: str | None = None
+    data: dict[str, Any] | None = None
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _resolve_template_path(repo_root: Path, rel: Path) -> Path | None:
+    """Prefer ``docs/templates/<basename>``; else ``.mat/docs/templates/<basename>`` (adopted layout)."""
+    basename = rel.name
+    primary = repo_root / "docs" / "templates" / basename
+    if primary.is_file():
+        return primary
+    alt = repo_root / ".mat" / "docs" / "templates" / basename
+    if alt.is_file():
+        return alt
+    return None
+
+
+def _load_adoption(repo_root: Path) -> dict[str, Any] | None:
+    p = repo_root / ADOPTION_REL
+    if not p.is_file():
+        return None
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _resolve_effective_enforce(
+    repo_root: Path, cli: EnforceMode
+) -> Literal["strict", "warn_first"]:
+    if cli in ("strict", "warn_first"):
+        return cli
+    env = os.environ.get("CURSOR_MAT_COST_HYGIENE_ENFORCE", "").strip().lower()
+    if env in ("strict", "warn_first"):
+        return env  # type: ignore[return-value]
+    adoption = _load_adoption(repo_root)
+    if adoption and adoption.get("enforcement") in ("strict", "warn_first"):
+        return adoption["enforcement"]  # type: ignore[return-value]
+    return "strict"
+
+
+def _warn_first_existing(adoption: dict[str, Any] | None, eff: str) -> bool:
+    if eff != "warn_first" or not adoption:
+        return False
+    return adoption.get("bootstrap_mode") == "existing-project"
+
+
+def _before_submit_empty_blockedlist(repo_root: Path) -> bool:
+    p = repo_root / BEFORE_SUBMIT_REL
+    if not p.is_file():
+        return False
+    in_list = False
+    for line in _read_text(p).splitlines():
+        if "blocked_patterns" in line and ": list" in line and "=" in line:
+            in_list = True
+            continue
+        if in_list:
+            t = line.strip()
+            if t.startswith("]"):
+                break
+            if not t or t.startswith("#"):
+                continue
+            if t.startswith("("):
+                return False
+    return in_list
+
+
+def analyze_pack(
+    repo_root: Path, *, effective_enforce: Literal["strict", "warn_first"]
+) -> list[Finding]:
+    """Return structured findings (use effective_enforce for severity mapping)."""
+    out: list[Finding] = []
+    adoption = _load_adoption(repo_root)
+    wfe = _warn_first_existing(adoption, effective_enforce)
+    eff = effective_enforce
+    # --- rule ---
+    rule_path = repo_root / RULE_REL
+    if not rule_path.is_file():
+        out.append(
+            Finding(
+                "pack.missing_rule", "FAIL", f"missing rule file: {RULE_REL}", str(RULE_REL)
+            )
+        )
+    else:
+        body = _read_text(rule_path)
+        for needle in RULE_REQUIRED_SUBSTRINGS:
+            if needle not in body:
+                out.append(
+                    Finding(
+                        "pack.rule_honesty_substring",
+                        "FAIL",
+                        f"rule file missing required substring {needle!r}: {RULE_REL}",
+                        str(RULE_REL),
+                        {"needle": needle},
+                    )
+                )
+        for needle in VERIFIER_SUBSTRINGS:
+            if needle not in body.lower():
+                out.append(
+                    Finding(
+                        "pack.rule_verifier_accountability",
+                        "FAIL",
+                        f"rule file missing accountability phrase {needle!r}: {RULE_REL}",
+                        str(RULE_REL),
+                    )
+                )
+
+    # --- all templates (MAT pack completeness) ---
+    for trel in ALL_TEMPLATE_RELS:
+        tpath = _resolve_template_path(repo_root, trel)
+        path_disp = str(tpath.relative_to(repo_root)) if tpath is not None else str(trel)
+        if tpath is None or not tpath.is_file():
+            out.append(
+                Finding(
+                    "pack.missing_template",
+                    "FAIL",
+                    f"missing template file: {trel}",
+                    path_disp,
+                )
+            )
+            continue
+        ttext = _read_text(tpath)
+        for frag in CURSORIGNORE_REQUIRED_FRAGMENTS:
+            if frag not in ttext:
+                out.append(
+                    Finding(
+                        "pack.template_fragment",
+                        "FAIL",
+                        f"template {trel} missing required fragment {frag!r}",
+                        path_disp,
+                    )
+                )
+        low = ttext.lower()
+        if "escape hatch" not in low:
+            out.append(
+                Finding(
+                    "pack.template_escape_hatch",
+                    "FAIL",
+                    f"template {trel} must include an escape hatch paragraph",
+                    path_disp,
+                )
+            )
+
+    # --- root .cursorignore ---
+    ignore_path = repo_root / IGNORE_REL
+    if not ignore_path.is_file():
+        out.append(
+            Finding(
+                "pack.missing_root_cursorignore",
+                "FAIL",
+                f"missing root cursorignore: {IGNORE_REL}",
+                str(IGNORE_REL),
+            )
+        )
+    else:
+        itext = _read_text(ignore_path)
+        for frag in CURSORIGNORE_REQUIRED_FRAGMENTS:
+            if frag not in itext:
+                sev: Severity = "FAIL"
+                if wfe:
+                    sev = "WARN"
+                out.append(
+                    Finding(
+                        "pack.root_cursorignore_fragment",
+                        sev,
+                        f".cursorignore missing recommended fragment {frag!r} "
+                        f"({'warn_first existing-project' if wfe else 'strict'})",
+                        str(IGNORE_REL),
+                    )
+                )
+        if "escape hatch" not in itext.lower() and "escape" not in itext.lower():
+            sev2: Severity = "WARN" if wfe else "INFO"
+            out.append(
+                Finding(
+                    "pack.root_cursorignore_escape_note",
+                    sev2,
+                    "root .cursorignore has no 'escape hatch' phrasing; prefer aligning with a MAT template or documenting narrowing policy",
+                    str(IGNORE_REL),
+                )
+            )
+
+    # --- CURSOR_VALIDATE_PROMPTS vs empty list (advisory) ---
+    env_sample = repo_root / ".env.sample"
+    validate_enabled_in_sample = False
+    if env_sample.is_file():
+        for line in _read_text(env_sample).splitlines():
+            s = line.strip()
+            if s.startswith("CURSOR_VALIDATE_PROMPTS=") and "true" in s.split("=", 1)[-1].lower():
+                validate_enabled_in_sample = True
+    if (repo_root / BEFORE_SUBMIT_REL).is_file() and _before_submit_empty_blockedlist(repo_root):
+        msg = (
+            "before_submit_prompt has an empty `blocked_patterns` list; with "
+            "`CURSOR_VALIDATE_PROMPTS=true` validation is a no-op until you add patterns"
+        )
+        sev3: Severity = "INFO"
+        if validate_enabled_in_sample:
+            sev3 = "WARN"
+        out.append(Finding("pack.validate_prompts_noop", sev3, msg, str(BEFORE_SUBMIT_REL)))
+
+    return out
+
+
+def _write_report_artifacts(
+    repo_root: Path, findings: list[Finding], effective_enforce: str
+) -> None:
+    out = repo_root / "artifacts" / "cost-hygiene"
+    out.mkdir(parents=True, exist_ok=True)
+    rep = {
+        "effective_enforce": effective_enforce,
+        "summary": {
+            "fail": sum(1 for f in findings if f.severity == "FAIL"),
+            "warn": sum(1 for f in findings if f.severity == "WARN"),
+            "info": sum(1 for f in findings if f.severity == "INFO"),
+        },
+        "findings": [asdict(f) for f in findings],
+    }
+    (out / "last-report.json").write_text(json.dumps(rep, indent=2) + "\n", encoding="utf-8")
+    line = json.dumps({**rep, "ts_utc": datetime.now(timezone.utc).isoformat()})
+    with (out / "report-events.jsonl").open("a", encoding="utf-8") as f:
+        f.write(line + "\n")
+
+
+def _print_findings(findings: list[Finding], *, warn_only: bool) -> None:
+    for f in findings:
+        if warn_only and f.severity == "INFO":
+            continue
+        pfx = f.severity
+        loc = f" {f.path}" if f.path else ""
+        print(f"{pfx}{loc}: {f.message} [{f.code}]", file=sys.stdout)
+
+
+def validate_pack(repo_root: Path) -> list[str]:
+    """Backward-compatible: messages for FAIL-level findings (auto/strict for unknown repos)."""
+    eff = _resolve_effective_enforce(repo_root, "auto")
+    return [f.message for f in analyze_pack(repo_root, effective_enforce=eff) if f.severity == "FAIL"]
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root (default: cwd)",
+    )
+    p.add_argument(
+        "--enforce",
+        choices=("strict", "warn_first", "auto"),
+        default="auto",
+        help="Enforcement mode (auto reads .mat/cost-hygiene-adoption.json, then env CURSOR_MAT_COST_HYGIENE_ENFORCE, else strict).",
+    )
+    p.add_argument(
+        "--report",
+        action="store_true",
+        help="Print all findings, write artifacts/cost-hygiene/last-report.json and append report-events.jsonl",
+    )
+    p.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="Omit INFO lines from printed output; implies --no-fail (exit 0).",
+    )
+    p.add_argument(
+        "--no-fail",
+        action="store_true",
+        help="Do not exit 1 when FAIL findings exist (doctor / local advisory)",
+    )
+    p.add_argument("--diagnostic", action="store_true", help="Alias for --no-fail")
+    args = p.parse_args()
+    repo_root = args.repo_root.resolve()
+    no_fail = bool(args.no_fail or args.diagnostic or args.warn_only)
+    eff = _resolve_effective_enforce(repo_root, args.enforce)  # type: ignore[arg-type]
+    findings = analyze_pack(repo_root, effective_enforce=eff)
+    if args.report:
+        _print_findings(findings, warn_only=bool(args.warn_only))
+        _write_report_artifacts(repo_root, findings, eff)
+    elif args.warn_only:
+        _print_findings(findings, warn_only=True)
+
+    has_fail = any(f.severity == "FAIL" for f in findings)
+    if not no_fail and has_fail:
+        if not args.report and not args.warn_only:
+            print("cost_context_hygiene_pack: FAIL", file=sys.stderr)
+            for f in findings:
+                if f.severity == "FAIL":
+                    pth = f" {f.path}" if f.path else ""
+                    print(f"  {f.severity}{pth}: {f.message}", file=sys.stderr)
+        return 1
+    if not args.report and not args.warn_only:
+        print("cost_context_hygiene_pack: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds tracked MAT sidecar (`.mat/`, `AGENTS.md` pointer, operator scripts, handoff docs).
- No plugin PHP or release behavior changes.
- `.cursor/` remains gitignored; operators bootstrap locally (see `docs/mat-adoption-notes.md`).
- Observability deferred per adoption appendix; `update-mat --apply` not in scope.
- Documents MAT vs `.cursor/` policy in `CONTRIBUTING.md`.

## Test plan
- [ ] `bash scripts/phase1-verify.sh` exit 0
- [ ] `bash scripts/doctor.sh` exit 0
- [ ] Diff contains no `*.php`, `composer.*`, or v1.0.9.2 assets